### PR TITLE
96 u documentation updates for STORY-3828

### DIFF
--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -143,6 +143,7 @@ Endpoint:
   :description: Update a signal
   :page: update_signal2
 
+
 Timestamp Formats
 -------------------------------
 
@@ -182,6 +183,9 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
     Example: **2016/04/11 13:00:00.000 PM**
 
     Example (no milliseconds): **2016/04/11 13:00:00 PM**
+
+    **Note:** The file upload user interface includes a timezone dropdown feature, which allows users to select which timezone this format is parsed in.
+
 
 
 Example POST Request Using cURL

--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -96,11 +96,11 @@ Used to create the fields of a signal.
 
     `value:` True or false as to whether the signal was met or not. Defaults to true if not passed. Can be a string ‘true’ or ‘false’, or 1 (true) or 0 (false).
 
-    `custom_paramter_1` Custom parameter. Up to 255 character string.
+    `custom_parameter_1` Custom parameter. Up to 255 character string.
 
-    `custom_paramter_2` Custom parameter. Up to 255 character string.
+    `custom_parameter_2` Custom parameter. Up to 255 character string.
 
-    `custom_paramter_3` Custom parameter. Up to 255 character string.
+    `custom_parameter_3` Custom parameter. Up to 255 character string.
 
 ------
 
@@ -173,15 +173,15 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
 
     Example (UTC): **2016/04/11T20:00:00.000Z**
 
-    Example (without milliseconds): **2016/04/11T13:00:00-07:00**
+    Example (no milliseconds): **2016/04/11T13:00:00-07:00**
 
 **Excel Compatible:** Timestamp parsed in the timezone of the **oauth token**'s associated network. Milliseconds are optional.
 
     Format: **YYYY/MM/DD HH:MM:SS.sss AM/PM**
 
-    Example (with milliseconds): **2016/04/11 13:00:00.000 PM**
+    Example: **2016/04/11 13:00:00.000 PM**
 
-    Example (without milliseconds): **2016/04/11 13:00:00 PM**
+    Example (no milliseconds): **2016/04/11 13:00:00 PM**
 
 
 Example POST Request Using cURL

--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -49,7 +49,7 @@ Used to find the call associated with the signal.
 
     or
 
-    `start_time_t:` 10 digit start time of the call in UTC seconds since 1/1/70, also known as Unix time_t. UTC milliseconds since 1/1/70 (which is the default in Javascript) are also supported, i.e. a 13 digit start time. The start time does not have to be exact since clocks will not be perfectly synchronized. We will find the closest match (in combination with **duration_in_seconds**, if provided)
+    `start_time_t:` The start time does not have to be exact since clocks will not be perfectly synchronized. We will find the closest match (in combination with **duration_in_seconds**, if provided). See **Timestamp Formats** section below for descriptions of supported timestamps.
 
     Note: If using **start_time_t** to match, instead of **transaction_id**, one or more of the following optional parameters is highly recommended. The optional parameters are ignored when using the **transaction_id**:
 
@@ -87,8 +87,7 @@ Used to create the fields of a signal.
 
     `description:` Free form text for providing additional details about the signal (for example: a sales order ID or a specific product being purchased or inquired about).
 
-    `occurred_at_time_t:` 10 digit time that the signal occurred, in UTC seconds since 1/1/70, also known as Unix time_t.
-    This allows batching of signal results at a later time and still capture the exact time the signal event happened. Defaults to the time of the API request if not provided.
+    `occurred_at_time_t:` This allows batching of signal results at a later time and still capture the exact time the signal event happened. See **Timestamp Formats** section below for descriptions of supported timestamps. Defaults to the time of the API request if not provided.
 
     `sale_amount:` Money with up to 2 decimal places (period separated).
     Assumed to be in the same currency as the organization that owns the signal being reported.
@@ -143,6 +142,42 @@ Endpoint:
   :path: /transactions/&lttransaction_id&gt/signals
   :description: Update a signal
   :page: update_signal2
+
+Timestamp Formats
+-------------------------------
+
+The following formats are supported for both `start_time_t` and `occurred_at_time_t`.
+
+All examples below correspond to a date time of **11 April 2016** at **1 PM Pacific Time**.
+
+
+**Epoch:** 10 digit timestamp in UTC seconds since 1/1/70, also known as Unix time_t. UTC milliseconds since 1/1/70 (which is the default in Javascript) are also supported, i.e. a 13 digit start time.
+
+    Example (10 digits): **1460404800**
+
+    Example (13 digits): **1460404800000**
+
+**ISO 8601:** Timestamp with +/- UTC offset or Z to indicate time is in UTC.
+
+    Format: **YYYY/MM/DDTHH:MM:SS.sss+hh:mm**
+
+    Example (UTC offset of +3 hours): **2016/04/11T23:00:00.000+03:00**
+
+    Example (UTC offset of -7 hours): **2016/04/11T13:00:00.000-07:00**
+
+    Example (UTC): **2016/04/11T20:00:00.000Z**
+
+**Compressed:** 17 digit timestamp always parsed in Pacific time.
+
+    Format: **YYYYMMDDHHMMSSsss**
+
+    Example: **20160411130000000**
+
+**Standard:** Timestamp parsed in the timezone of the **oauth token**'s associated network.
+
+    Format: **YYYY/MM/DD HH:MM:SS.sss AM/PM**
+
+    Example: **2016/04/11 13:00:00.000 PM**
 
 
 Example POST Request Using cURL

--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -157,7 +157,13 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
 
     Example (13 digits): **1460404800000**
 
-**ISO 8601:** Timestamp with +/- UTC offset or Z to indicate time is in UTC.
+**Compressed:** 17 digit timestamp always parsed in Pacific time.
+
+    Format: **YYYYMMDDHHMMSSsss**
+
+    Example: **20160411130000000**
+
+**ISO 8601:** Timestamp with +/- UTC offset or Z to indicate time is in UTC. Milliseconds are optional.
 
     Format: **YYYY/MM/DDTHH:MM:SS.sss+hh:mm**
 
@@ -167,17 +173,15 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
 
     Example (UTC): **2016/04/11T20:00:00.000Z**
 
-**Compressed:** 17 digit timestamp always parsed in Pacific time.
+    Example (without milliseconds): **2016/04/11T13:00:00-07:00**
 
-    Format: **YYYYMMDDHHMMSSsss**
-
-    Example: **20160411130000000**
-
-**Standard:** Timestamp parsed in the timezone of the **oauth token**'s associated network.
+**Excel Compatible:** Timestamp parsed in the timezone of the **oauth token**'s associated network. Milliseconds are optional.
 
     Format: **YYYY/MM/DD HH:MM:SS.sss AM/PM**
 
-    Example: **2016/04/11 13:00:00.000 PM**
+    Example (with milliseconds): **2016/04/11 13:00:00.000 PM**
+
+    Example (without milliseconds): **2016/04/11 13:00:00 PM**
 
 
 Example POST Request Using cURL

--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -184,7 +184,7 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
 
     Example (no milliseconds): **2016/04/11 13:00:00 PM**
 
-    **Note:** The file upload user interface includes a timezone dropdown feature, which allows users to select which timezone this format is parsed in.
+    **Note:** The file upload user interface includes a timezone dropdown feature, which allows users to select which timezone this format is parsed in. Use the following to format Excel date cells: **yyyy/mm/dd hh:mm:ss.000 AM/PM**.
 
 
 

--- a/source/api_documentation/transactions_api/voice_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/voice_signal_param_table.rst
@@ -39,7 +39,7 @@ Voice Signal Parameters
     - Voice Signals are configurable metrics that are tracked across calls, configured with rules about when the Voice Signal is met (1 if Voice Signal is met, 0 if Voice Signal was applied to the call but not met, null if Voice Signal was not applied to call)
 
   * - signal_8_value
-    - Voice Signal: Telecom Competitors
+    - Voice Signal: Competitors
     - Voice Signals are configurable metrics that are tracked across calls, configured with rules about when the Voice Signal is met (1 if Voice Signal is met, 0 if Voice Signal was applied to the call but not met, null if Voice Signal was not applied to call)
 
   * - signal_9_value


### PR DESCRIPTION
This PR adds information to the SAPI documentation for supported timestamp formats. 

Below is a picture of the descriptions:

![screen shot 2016-04-11 at 4 42 05 pm](https://cloud.githubusercontent.com/assets/10349516/14445702/5d1bd0ca-0004-11e6-941a-aa87d375a137.png)
