### PR TITLE
STORY-4307 update SAPI timestamp default from Pacific to UTC

### DIFF
--- a/source/api_documentation/signal_api/index.rst
+++ b/source/api_documentation/signal_api/index.rst
@@ -158,7 +158,7 @@ All examples below correspond to a date time of **11 April 2016** at **1 PM Paci
 
     Example (13 digits): **1460404800000**
 
-**Compressed:** 17 digit timestamp always parsed in Pacific time.
+**Compressed:** 17 digit timestamp always parsed in UTC.
 
     Format: **YYYYMMDDHHMMSSsss**
 


### PR DESCRIPTION
Updates SAPI timestamp documentation for compressed format to always parse in UTC.
