### PR TITLE
STORY-6250: rename affiliate campaign relationship endpoint

### DIFF
--- a/source/api_documentation/network_integration/advertiser_affiliate_relationships/index.rst
+++ b/source/api_documentation/network_integration/advertiser_affiliate_relationships/index.rst
@@ -1,8 +1,11 @@
-Advertiser Affiliate Relationships
+Auto-Approve Affiliate to Campaigns
 ==================================
 
 Changes to the Relationship between Advertiser and Affiliate on the network platform are replicated to the Invoca platform using this API.
 The operations on Advertiser‐Affiliate Relationships are similar to Network, in that the interface is fully idempotent, and the create and update commands will act as “create or update”.
+
+When setting the Relationship between an Advertiser and Affiliate to Approved, all current and future campaign applications made between the Affiliate and Advertiser will be auto-approved. 
+If the Relationship is set to any status other than Approved, all current and future applications will be declined and any active affiliate campaigns will be suspended.
 
 Relationship status is set individually but reading is available for one or all relationships for an advertiser.
 

--- a/source/api_documentation/network_integration/index.rst
+++ b/source/api_documentation/network_integration/index.rst
@@ -11,7 +11,7 @@ Advertiser Campaigns
 Campaign Terms
 RingPools
 Promo Numbers
-Advertiser Affiliate Relationships
+Auto-Approve Affiliate to Campaigns
 
 Terminology
 


### PR DESCRIPTION
After talking with Lauren, we like this name enough that we're going to backfill this name change to all previous versions.  I'll just cherrypick this commit to other versions when this is approved.