### PR TITLE
2016 10 01 removed unwanted constants for affiliates

### DIFF
--- a/source/api_documentation/transactions_api/_affiliate_intro_constants.rst
+++ b/source/api_documentation/transactions_api/_affiliate_intro_constants.rst
@@ -1,0 +1,3 @@
+We provide a helpful constant that can be used in the include_columns and exclude_columns options:
+
+    `$invoca_default_columns` represents the default set of columns provided by the Transactions API for your requested version

--- a/source/api_documentation/transactions_api/_intro.rst
+++ b/source/api_documentation/transactions_api/_intro.rst
@@ -54,10 +54,5 @@ you should store the last transaction id you have downloaded and pass it as the 
 Typical usage on the polling interval is to repeatedly call the API until no rows are returned, meaning you have downloaded all transactions.
 Please note, the "to" and "from" date range parameters are both necessary, providing only one or the other will not filter the results.
 
-We provide two helpful constants that can be used in the include_columns and exclude_columns options:
-
-    `$invoca_custom_columns` a dynamic constant that represents the current list of your Custom Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_columns", independent of the API version.
-
-    `$invoca_default_columns` represents the default set of columns provided by the Transactions API for your requested version
 
 

--- a/source/api_documentation/transactions_api/_intro_constants.rst
+++ b/source/api_documentation/transactions_api/_intro_constants.rst
@@ -1,0 +1,5 @@
+We provide two helpful constants that can be used in the include_columns and exclude_columns options:
+
+    `$invoca_custom_columns` a dynamic constant that represents the current list of your Custom Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_columns", independent of the API version.
+
+    `$invoca_default_columns` represents the default set of columns provided by the Transactions API for your requested version

--- a/source/api_documentation/transactions_api/advertiser_user.rst
+++ b/source/api_documentation/transactions_api/advertiser_user.rst
@@ -26,6 +26,7 @@ The API follows REST conventions. Perform an HTTPS GET to the URL with the forma
 
 
 .. include:: _intro.rst
+.. include:: _intro_constants.rst
 
 
 Response

--- a/source/api_documentation/transactions_api/affiliate_user.rst
+++ b/source/api_documentation/transactions_api/affiliate_user.rst
@@ -26,6 +26,7 @@ The API follows REST conventions. Perform an HTTPS GET to the URL with the forma
 
 
 .. include:: _intro.rst
+.. include:: _affiliate_intro_constants.rst
 
 
 Response

--- a/source/api_documentation/transactions_api/network_user.rst
+++ b/source/api_documentation/transactions_api/network_user.rst
@@ -26,6 +26,7 @@ The API follows REST conventions. Perform an HTTPS GET to the URL with the forma
 
 
 .. include:: _intro.rst
+.. include:: _intro_constants.rst
 
 
 Response


### PR DESCRIPTION
Updated the Older version retaining with 2 options for Network & Advertiser Users, and updated into a single option for Affiliates