### PR TITLE
2019-02-01 Fixing the typo:

### DIFF
--- a/source/api_documentation/transactions_api/_intro_constants.rst
+++ b/source/api_documentation/transactions_api/_intro_constants.rst
@@ -1,4 +1,4 @@
-We provide two helpful constants that can be used in the include_columns and exclude_columns options:
+We provide three helpful constants that can be used in the include_columns and exclude_columns options:
 
     `$invoca_custom_columns` a dynamic constant that represents the current list of your Custom Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_columns", independent of the API version. See Custom Data Parameters section for more details.
 


### PR DESCRIPTION
Fixed the typo from "two" to "three" for Transactions API, network and affiliate users.