### PR TITLE
Implement 2019-11-01

### DIFF
--- a/source/api_documentation/transactions_api/_rollup_message.rst
+++ b/source/api_documentation/transactions_api/_rollup_message.rst
@@ -1,0 +1,14 @@
+.. TODO: ORabani - rough draft... add "regardless of feature settings"?
+.. raw:: html
+
+  <h2>
+    Signal Transactions Rollup
+  </h2>
+  <div class="alert alert-danger">
+    <p>
+      Starting with version <b>2019-11-01</b>, all future API versions will only return rollup rows of transaction types "Call" and "Post Call Event".
+    </p>
+    <p>
+      For more information, view the support documentation for <a href="https://invoca.force.com/community/s/article/How-to-access-Invoca-call-data-programmatically-via-API" target="_blank">best practices in accessing Invoca Call Data via the Transactions API</a>.
+    </p>
+  </div>

--- a/source/api_documentation/transactions_api/_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/_signal_param_table.rst
@@ -14,14 +14,6 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
     - Name in Reports
     - Description
 
-  * - signal_name *(deprecated)*
-    - Signal Name
-    - The name describing the signal event. See the Custom Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction.
-
-  * - signal_description *(deprecated)*
-    - Signal Description
-    - Free form text for providing additional details about the signal. *(Removed for Signal Transactions Rollup)*
-
   * - signal_partner_unique_id
     - Signal Partner ID
     - Unique identifier, to distinguish between updating an existing Signal or Post Call Event (for example correcting a sale that was reported) versus adding a second sale or Post call Event to the call (for example a reservation made while on the call and then an add on item purchased later).
@@ -30,27 +22,6 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
     - Signal Occurred At
     - 10 digit time that the signal occurred, in UTC seconds since 1/1/70, also known as Unix time_t.
 
-  * - signal_source *(deprecated)*
-    - Signal Source
-    - The source of the signal.  Possible values are :UserOverride, :Api, :Import, :Expression, :Ivr, and :Machine
-
-  * - signal_value *(deprecated)*
-    - Signal Value
-    - True or false as to whether or not the signal was met and null if it is not a signal transaction. *(Removed for Signal Transactions Rollup)*
-
   * - revenue
     - Revenue (Sale Amount)
     - The revenue applied to the call via Signal revenue proxies or Post Call Events.
-
-  * - signal_custom_parameter_1 *(deprecated)*
-    - Signal Custom Param 1
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
-
-  * - signal_custom_parameter_2 *(deprecated)*
-    - Signal Custom Param 2
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
-
-  * - signal_custom_parameter_3 *(deprecated)*
-    - Signal Custom Param 3
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
-

--- a/source/api_documentation/transactions_api/_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/_signal_param_table.rst
@@ -14,6 +14,10 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
     - Name in Reports
     - Description
 
+  * - signal_name *(deprecated)*
+    - Signal Name
+    - The name describing the signal event. See the Custom Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction.
+
   * - signal_partner_unique_id
     - Signal Partner ID
     - Unique identifier, to distinguish between updating an existing Signal or Post Call Event (for example correcting a sale that was reported) versus adding a second sale or Post call Event to the call (for example a reservation made while on the call and then an add on item purchased later).
@@ -21,6 +25,10 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
   * - signal_occurred_at
     - Signal Occurred At
     - 10 digit time that the signal occurred, in UTC seconds since 1/1/70, also known as Unix time_t.
+
+  * - signal_source *(deprecated)*
+    - Signal Source
+    - The source of the signal.  Possible values are :UserOverride, :Api, :Import, :Expression, :Ivr, and :Machine
 
   * - revenue
     - Revenue (Sale Amount)

--- a/source/api_documentation/transactions_api/advertiser_user.rst
+++ b/source/api_documentation/transactions_api/advertiser_user.rst
@@ -2,6 +2,8 @@
 Advertiser / Merchant
 #####################
 
+.. include:: _rollup_message.rst
+
 URL
 ---
 

--- a/source/api_documentation/transactions_api/affiliate_user.rst
+++ b/source/api_documentation/transactions_api/affiliate_user.rst
@@ -2,6 +2,8 @@
 Publisher / Affiliate
 #####################
 
+.. include:: _rollup_message.rst
+
 URL
 ---
 

--- a/source/api_documentation/transactions_api/network_user.rst
+++ b/source/api_documentation/transactions_api/network_user.rst
@@ -2,12 +2,7 @@
 Network / Brand
 ################
 
-.. raw:: html
-
-  <p>
-    View the support documentation for <a href="https://invoca.force.com/community/s/article/How-to-access-Invoca-call-data-programmatically-via-API">best practices in accessing Invoca Call Data via the Transactions API</a>.
-  </p>
-
+.. include:: _rollup_message.rst
 
 URL
 ---

--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,11 +1,11 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2019-05-01'
+COMMON_VERSION = '2019-11-01'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':     '2018-11-01',
     '@@CONVERSION_API_VERSION':  '2014-04-15',
-    '@@TRANSACTION_API_VERSION': '2019-05-01',
+    '@@TRANSACTION_API_VERSION': '2019-11-01',
     '@@RINGPOOL_API_VERSION':    '2015-12-09',
     '@@PNAPI_VERSION':           '2013-07-01',
     '@@SIGNAL_API_VERSION':      '2018-02-01'


### PR DESCRIPTION
### NOTE
This PR is for comparison purposes only. We'll need to follow the README steps to fully implement a `2019-12-01` branch.

### Details
* Add signal transactions api rollup message for `2019-12-01`.
  * This is still WIP as we should get confirmation with product on what the specific verbiage should be.
* Remove the deprecated signal columns that will no longer be returned for api versions greater than `2019-05-01`.
