### PR TITLE
2019-05-01 rollup field descriptions: Append rollup messages to signal tx rollup affected fields

### DIFF
--- a/source/api_documentation/transactions_api/_advertiser_optional_param_table.rst
+++ b/source/api_documentation/transactions_api/_advertiser_optional_param_table.rst
@@ -1,4 +1,4 @@
-
+.. include:: _signal_transaction_rollup_replacements.rst
 
 ..  list-table::
   :widths: 30 8 40
@@ -11,7 +11,7 @@
 
   * - advertiser_call_fee_localized
     - Fees
-    - Advertiser Telecommunications fee associated with transaction
+    - Advertiser Telecommunications fee associated with transaction |rollup_summed_total_message|
 
   * - affiliate_campaign_id_from_network
     - Affiliate Campaign ID

--- a/source/api_documentation/transactions_api/_advertiser_param_table.rst
+++ b/source/api_documentation/transactions_api/_advertiser_param_table.rst
@@ -63,7 +63,7 @@
 
   * - call_source_description
     - Source
-    - Source of the transaction |rollup_affects_call_message|
+    - Source of the transaction
 
   * - calling_phone_number
     - Caller ID

--- a/source/api_documentation/transactions_api/_advertiser_param_table.rst
+++ b/source/api_documentation/transactions_api/_advertiser_param_table.rst
@@ -1,4 +1,4 @@
-
+.. include:: _signal_transaction_rollup_replacements.rst
 
 ..  list-table::
   :widths: 30 8 40
@@ -27,7 +27,7 @@
 
   * - advertiser_payin_localized
     - Earned
-    - Amount paid in by advertiser
+    - Amount paid in by advertiser |rollup_summed_total_message|
 
   * - advertiser_promo_line_description
     - Promo Number Description
@@ -59,11 +59,11 @@
 
   * - call_result_description_detail_managed_advertiser
     - Call Result
-    - Status of the transaction
+    - Status of the transaction |rollup_affects_call_message|
 
   * - call_source_description
     - Source
-    - Source of the transaction
+    - Source of the transaction |rollup_affects_call_message|
 
   * - calling_phone_number
     - Caller ID

--- a/source/api_documentation/transactions_api/_affiliate_optional_param_table.rst
+++ b/source/api_documentation/transactions_api/_affiliate_optional_param_table.rst
@@ -11,7 +11,7 @@
 
   * - signal_name
     - Signal Name
-    - The name describing the signal event.
+    - The name describing the signal event. |rollup_merged_message|
 
   * - external_data
     - External Data

--- a/source/api_documentation/transactions_api/_affiliate_param_table.rst
+++ b/source/api_documentation/transactions_api/_affiliate_param_table.rst
@@ -43,7 +43,7 @@
 
   * - call_source_description
     - Source
-    - Source of the transaction |rollup_affects_call_message|
+    - Source of the transaction
 
   * - city
     - City

--- a/source/api_documentation/transactions_api/_affiliate_param_table.rst
+++ b/source/api_documentation/transactions_api/_affiliate_param_table.rst
@@ -1,4 +1,4 @@
-
+.. include:: _signal_transaction_rollup_replacements.rst
 
 ..  list-table::
   :widths: 30 8 40
@@ -35,15 +35,15 @@
 
   * - affiliate_payout_localized
     - Earnings
-    - Amount paid out to the affiliate
+    - Amount paid out to the affiliate |rollup_summed_total_message|
 
   * - call_result_description_detail
     - Call Result
-    - Status of the transaction
+    - Status of the transaction |rollup_affects_call_message|
 
   * - call_source_description
     - Source
-    - Source of the transaction
+    - Source of the transaction |rollup_affects_call_message|
 
   * - city
     - City

--- a/source/api_documentation/transactions_api/_network_param_table.rst
+++ b/source/api_documentation/transactions_api/_network_param_table.rst
@@ -83,7 +83,7 @@
 
   * - call_source_description
     - Source
-    - Source of the transaction |rollup_affects_call_message|
+    - Source of the transaction
 
   * - calling_phone_number
     - Caller ID

--- a/source/api_documentation/transactions_api/_network_param_table.rst
+++ b/source/api_documentation/transactions_api/_network_param_table.rst
@@ -1,4 +1,4 @@
-
+.. include:: _signal_transaction_rollup_replacements.rst
 
 ..  list-table::
   :widths: 30 8 40
@@ -11,7 +11,7 @@
 
   * - advertiser_call_fee_localized
     - Advertiser Fees
-    - Advertiser Telecommunications fee associated with transaction
+    - Advertiser Telecommunications fee associated with transaction |rollup_summed_total_message|
 
   * - advertiser_campaign_id
     - Advertiser Campaign ID (Invoca ID)
@@ -43,7 +43,7 @@
 
   * - advertiser_payin_localized
     - Earned
-    - Amount paid in by advertiser
+    - Amount paid in by advertiser |rollup_summed_total_message|
 
   * - affiliate_call_volume_ranking
     - Affiliate Volume Ranking
@@ -71,19 +71,19 @@
 
   * - affiliate_payout_localized
     - Paid
-    - Amount paid out to the affiliate
+    - Amount paid out to the affiliate |rollup_summed_total_message|
 
   * - call_fee_localized
     - Fees
-    - Telecommunications fee associated with transaction
+    - Telecommunications fee associated with transaction |rollup_affects_call_message|
 
   * - call_result_description_detail
     - Call Result
-    - Status of the transaction
+    - Status of the transaction |rollup_affects_call_message|
 
   * - call_source_description
     - Source
-    - Source of the transaction
+    - Source of the transaction |rollup_affects_call_message|
 
   * - calling_phone_number
     - Caller ID

--- a/source/api_documentation/transactions_api/_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/_signal_param_table.rst
@@ -1,4 +1,4 @@
-
+.. include:: _signal_transaction_rollup_replacements.rst
 
 Signal Parameters
 *****************
@@ -16,11 +16,11 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
 
   * - signal_name *(deprecated)*
     - Signal Name
-    - The name describing the signal event. See the Custom Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction.
+    - The name describing the signal event. See the Custom Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction. |rollup_merged_message|
 
   * - signal_description *(deprecated)*
     - Signal Description
-    - Free form text for providing additional details about the signal. *(Removed for Signal Transactions Rollup)*
+    - Free form text for providing additional details about the signal. |rollup_removed_message|
 
   * - signal_partner_unique_id
     - Signal Partner ID
@@ -32,11 +32,11 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
 
   * - signal_source *(deprecated)*
     - Signal Source
-    - The source of the signal.  Possible values are :UserOverride, :Api, :Import, :Expression, :Ivr, and :Machine
+    - The source of the signal.  Possible values are :UserOverride, :Api, :Import, :Expression, :Ivr, and :Machine. |rollup_removed_message|
 
   * - signal_value *(deprecated)*
     - Signal Value
-    - True or false as to whether or not the signal was met and null if it is not a signal transaction. *(Removed for Signal Transactions Rollup)*
+    - True or false as to whether or not the signal was met and null if it is not a signal transaction. |rollup_removed_message|
 
   * - revenue
     - Revenue (Sale Amount)
@@ -44,13 +44,13 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
 
   * - signal_custom_parameter_1 *(deprecated)*
     - Signal Custom Param 1
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
+    - Up to 255 character string. |rollup_removed_message|
 
   * - signal_custom_parameter_2 *(deprecated)*
     - Signal Custom Param 2
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
+    - Up to 255 character string. |rollup_removed_message|
 
   * - signal_custom_parameter_3 *(deprecated)*
     - Signal Custom Param 3
-    - Up to 255 character string. *(Removed for Signal Transactions Rollup)*
+    - Up to 255 character string. |rollup_removed_message|
 

--- a/source/api_documentation/transactions_api/_signal_transaction_rollup_replacements.rst
+++ b/source/api_documentation/transactions_api/_signal_transaction_rollup_replacements.rst
@@ -1,0 +1,4 @@
+.. |rollup_summed_total_message| replace:: *(Summed total amount for the call for Signal Transactions Rollup)*
+.. |rollup_removed_message| replace:: *(Removed for Signal Transactions Rollup)*
+.. |rollup_affects_call_message| replace:: *(For the call for Signal Transactions Rollup)*
+.. |rollup_merged_message| replace:: *(Merged results for the call for Signal Transactions Rollup)*


### PR DESCRIPTION
Given that these descriptions are being added in order to help other aspects of the platform as it currently is (such as the webhooks and the UI), I'd argue it's not worth updating past versions of the API docs.

Also please point out any other fields that would benefit from appended rollup related descriptions.