### PR TITLE
implement 2020-10-01: Add 2020-10-01 TX API docs with message about rollup

### DIFF
--- a/source/api_documentation/transactions_api/_rollup_message.rst
+++ b/source/api_documentation/transactions_api/_rollup_message.rst
@@ -5,7 +5,7 @@
   </h2>
   <div class="alert alert-danger">
     <p>
-      API versions <b>2019-12-01</b> and later only return rollup rows of transaction types "Call", "Sale", and "Post Call Event".
+      API versions <b>2020-10-01</b> and later only return rollup rows of transaction types "Call", "Sale", and "Post Call Event".
     </p>
     <p>
       For more information, view the support documentation for <a href="https://invoca.force.com/community/s/article/How-to-access-Invoca-call-data-programmatically-via-API" target="_blank">best practices in accessing Invoca Call Data via the Transactions API</a>.

--- a/source/api_documentation/transactions_api/_rollup_message.rst
+++ b/source/api_documentation/transactions_api/_rollup_message.rst
@@ -1,0 +1,13 @@
+.. raw:: html
+
+  <h2>
+    Signal Transactions Rollup
+  </h2>
+  <div class="alert alert-danger">
+    <p>
+      API versions <b>2019-12-01</b> and later only return rollup rows of transaction types "Call", "Sale", and "Post Call Event".
+    </p>
+    <p>
+      For more information, view the support documentation for <a href="https://invoca.force.com/community/s/article/How-to-access-Invoca-call-data-programmatically-via-API" target="_blank">best practices in accessing Invoca Call Data via the Transactions API</a>.
+    </p>
+  </div>

--- a/source/api_documentation/transactions_api/_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/_signal_param_table.rst
@@ -53,4 +53,3 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
   * - signal_custom_parameter_3 *(deprecated)*
     - Signal Custom Param 3
     - Up to 255 character string. |rollup_removed_message|
-

--- a/source/api_documentation/transactions_api/advertiser_user.rst
+++ b/source/api_documentation/transactions_api/advertiser_user.rst
@@ -2,6 +2,8 @@
 Advertiser / Merchant
 #####################
 
+.. include:: _rollup_message.rst
+
 URL
 ---
 

--- a/source/api_documentation/transactions_api/affiliate_user.rst
+++ b/source/api_documentation/transactions_api/affiliate_user.rst
@@ -2,6 +2,8 @@
 Publisher / Affiliate
 #####################
 
+.. include:: _rollup_message.rst
+
 URL
 ---
 

--- a/source/api_documentation/transactions_api/network_user.rst
+++ b/source/api_documentation/transactions_api/network_user.rst
@@ -2,12 +2,7 @@
 Network / Brand
 ################
 
-.. raw:: html
-
-  <p>
-    View the support documentation for <a href="https://invoca.force.com/community/s/article/How-to-access-Invoca-call-data-programmatically-via-API">best practices in accessing Invoca Call Data via the Transactions API</a>.
-  </p>
-
+.. include:: _rollup_message.rst
 
 URL
 ---

--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,12 +1,12 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2019-05-01'
+COMMON_VERSION = '2020-10-01'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':           '2018-11-01',
     '@@CAMPAIGN_FEATURES_API_VERSION': '2019-05-01',
     '@@CONVERSION_API_VERSION':        '2014-04-15',
-    '@@TRANSACTION_API_VERSION':       '2019-05-01',
+    '@@TRANSACTION_API_VERSION':       '2020-10-01',
     '@@RINGPOOL_API_VERSION':          '2015-12-09',
     '@@PNAPI_VERSION':                 '2013-07-01',
     '@@SIGNAL_API_VERSION':            '2018-02-01'


### PR DESCRIPTION
[STORY-7731](https://ringrevenue.atlassian.net/browse/STORY-7731)

**NOTE**
This PR is for comparison purposes only. We'll need to follow the README steps to fully implement a `2020-10-01` branch and make that the default branch.

Previous PR: https://github.com/Invoca/developer-docs/pull/238

* Add a new `2020-10-01` API version.
  * Add signal transactions api rollup message for `2019-12-01`.

![image](https://user-images.githubusercontent.com/9993068/97091322-0bd86f00-15f0-11eb-8074-8861cc18db14.png)

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] ~If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)~ N/A
