### PR TITLE
STORY-9864 updated transactions_api docs to read marketing data

### DIFF
--- a/source/api_documentation/transactions_api/_custom_data_params.rst
+++ b/source/api_documentation/transactions_api/_custom_data_params.rst
@@ -1,17 +1,17 @@
 
 
-Custom Data & Signal Parameters
+Marketing Data & Signal Parameters
 **********************
 
-Please click  `this link <https://www2.invoca.net/customer_data_dictionary/home>`_ to access the custom data parameters specific to your account.
+Please click  `this link <https://www2.invoca.net/customer_data_dictionary/home>`_ to access the Marketing Data parameters specific to your account.
 
-The Partner (API) Name is used as the field name returned by the Transactions API. Any Custom Data or Signal fields named the same as a standard Invoca Transactions API field will be returned by the API rather than the standard field. If any field names have spaces in their name, XML format will not be supported.
+The Partner (API) Name is used as the field name returned by the Transactions API. Any Marketing Data or Signal fields named the same as a standard Invoca Transactions API field will be returned by the API rather than the standard field. If any field names have spaces in their name, XML format will not be supported.
 
-**Custom Data & Signal can be accessed in two ways by Transactions API**
+**Marketing Data & Signal can be accessed in two ways by Transactions API**
 
-1. (JSON & XML formats only) By including `custom_data` as field in the `include_columns` parameter (e.g. `include_columns=transaction_id,start_time_local,custom_data`) a nested structure is returned containing all of the Custom Data and Signals that were specified for the given transaction. Note: null values are not returned.
+1. (JSON & XML formats only) By including `custom_data` as field in the `include_columns` parameter (e.g. `include_columns=transaction_id,start_time_local,custom_data`) a nested structure is returned containing all of the Marketing Data and Signals that were specified for the given transaction. Note: null values are not returned.
 
-Array of Custom Data Objects
+Array of Marketing Data Objects
 
 ..  list-table::
   :widths: 30 8 40
@@ -24,7 +24,7 @@ Array of Custom Data Objects
 
   * - name
     - String
-    - Custom Data Partner (API) Name or Signal Name. Up to 255 characters.
+    - Marketing Data Partner (API) Name or Signal Name. Up to 255 characters.
 
   * - data_type
     - String
@@ -88,7 +88,7 @@ Example response:
   ]
 
 
-2. (All formats) Custom Data and Signal fields can be accessed in the response by specifying the special `$invoca_custom_columns` constant in your `include_columns` parameter, or mentioning specific fields that you want to include, e.g. `include_columns=transaction_id,start_time_local,utm_medium,gclid,Quote,Purchase%20Made`.
+2. (All formats) Marketing Data and Signal fields can be accessed in the response by specifying the special `$invoca_custom_columns` constant in your `include_columns` parameter, or mentioning specific fields that you want to include, e.g. `include_columns=transaction_id,start_time_local,utm_medium,gclid,Quote,Purchase%20Made`.
 
 
 Example response:
@@ -114,7 +114,7 @@ Example response:
     }
   ]
 
-To also get the source of each Custom Data & Signal field, specify the special `$invoca_custom_source_columns` constant in your `include_columns` parameter. Doing that would result in an additional ".source" field for every Custom Data & Signal field:
+To also get the source of each Marketing Data & Signal field, specify the special `$invoca_custom_source_columns` constant in your `include_columns` parameter. Doing that would result in an additional ".source" field for every Marketing Data & Signal field:
 
 .. code-block:: json
 

--- a/source/api_documentation/transactions_api/_intro_constants.rst
+++ b/source/api_documentation/transactions_api/_intro_constants.rst
@@ -1,7 +1,7 @@
 We provide three helpful constants that can be used in the include_columns and exclude_columns options:
 
-    `$invoca_custom_columns` a dynamic constant that represents the current list of your Custom Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_columns", independent of the API version. See Custom Data Parameters section for more details.
+    `$invoca_custom_columns` a dynamic constant that represents the current list of your Marketing Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_columns", independent of the API version. See Marketing Data Parameters section for more details.
 
-    `$invoca_custom_source_columns` a dynamic constant that represents the sources for the current list of your Custom Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_source_columns", independent of the API version. See Custom Data Parameters section for more details.
+    `$invoca_custom_source_columns` a dynamic constant that represents the sources for the current list of your Marketing Data Fields. Note: If the list of custom columns changes, those changes will be included in future API calls that use "include_columns=$invoca_custom_source_columns", independent of the API version. See Marketing Data Parameters section for more details.
 
     `$invoca_default_columns` represents the default set of columns provided by the Transactions API for your requested version

--- a/source/api_documentation/transactions_api/_marketing_data_params.rst
+++ b/source/api_documentation/transactions_api/_marketing_data_params.rst
@@ -3,7 +3,7 @@
 Marketing Data & Signal Parameters
 **********************
 
-Please click  `this link <https://www2.invoca.net/customer_data_dictionary/home>`_ to access the Marketing Data parameters specific to your account.
+Please click  `this link <https://www2.invoca.net/customer_data_dictionary/home>`_ to access the marketing data parameters specific to your account.
 
 The Partner (API) Name is used as the field name returned by the Transactions API. Any Marketing Data or Signal fields named the same as a standard Invoca Transactions API field will be returned by the API rather than the standard field. If any field names have spaces in their name, XML format will not be supported.
 

--- a/source/api_documentation/transactions_api/_network_param_table.rst
+++ b/source/api_documentation/transactions_api/_network_param_table.rst
@@ -110,7 +110,7 @@
     - [Correction only] Id of the original transaction that this transaction updates. Values in this row are the corrected ones and should replace the original values. Same format as transaction_id. Up-to 32 character string, can contain alphanumeric characters (i.e. 0-9A-Z) and the -.
 
   * - custom_data
-    - Array of Custom Data Values
+    - Array of Marketing Data Values
     - JSON and XML formats only. This field is not included in response by default, and must be specified in the "include_columns" parameter. See table below for more information about the structure of this array.
 
   * - destination_phone_number

--- a/source/api_documentation/transactions_api/_signal_param_table.rst
+++ b/source/api_documentation/transactions_api/_signal_param_table.rst
@@ -3,7 +3,7 @@
 Signal Parameters
 *****************
 
-Most of the fields in this table are now deprecated. See Custom Data & Signal Parameters section for best practices for accessing Signal name, source and value. Additionally, some fields will be removed if the Signal Transactions Rollup feature is enabled.
+Most of the fields in this table are now deprecated. See Marketing Data & Signal Parameters section for best practices for accessing Signal name, source and value. Additionally, some fields will be removed if the Signal Transactions Rollup feature is enabled.
 
 ..  list-table::
   :widths: 30 8 40
@@ -16,7 +16,7 @@ Most of the fields in this table are now deprecated. See Custom Data & Signal Pa
 
   * - signal_name *(deprecated)*
     - Signal Name
-    - The name describing the signal event. See the Custom Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction. |rollup_merged_message|
+    - The name describing the signal event. See the Marketing Data Parameters section for an updated way of accessing the Signal(s) that are true on a given transaction. |rollup_merged_message|
 
   * - signal_description *(deprecated)*
     - Signal Description

--- a/source/api_documentation/transactions_api/advertiser_user.rst
+++ b/source/api_documentation/transactions_api/advertiser_user.rst
@@ -45,7 +45,7 @@ General Parameters
 
 .. include:: _conversion_reporting_param_table.rst
 
-.. include:: _custom_data_params.rst
+.. include:: _marketing_data_params.rst
 
 .. include:: _signal_param_table.rst
 
@@ -67,7 +67,7 @@ Example 1: Get the next 20 transactions that occurred after transaction id C624D
   curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
 
 
-Example 2: Get 50 rows from a specific time period with only the transaction_id and all Custom Data columns:
+Example 2: Get 50 rows from a specific time period with only the transaction_id and all Marketing Data columns:
 
 .. code-block:: bash
 

--- a/source/api_documentation/transactions_api/network_user.rst
+++ b/source/api_documentation/transactions_api/network_user.rst
@@ -45,7 +45,7 @@ General Parameters
 
 .. include:: _conversion_reporting_param_table.rst
 
-.. include:: _custom_data_params.rst
+.. include:: _marketing_data_params.rst
 
 .. include:: _signal_param_table.rst
 
@@ -66,7 +66,7 @@ Example 1: Get the next 20 transactions that occurred after transaction id C624D
   curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
 
 
-Example 2: Get 50 rows from a specific time period with only the transaction_id and all Custom Data columns:
+Example 2: Get 50 rows from a specific time period with only the transaction_id and all Marketing Data columns:
 
 .. code-block:: bash
 

--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,12 +1,12 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2020-10-01'
+COMMON_VERSION = '2021-08-09'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':           '2018-11-01',
     '@@CAMPAIGN_FEATURES_API_VERSION': '2019-05-01',
     '@@CONVERSION_API_VERSION':        '2014-04-15',
-    '@@TRANSACTION_API_VERSION':       '2020-10-01',
+    '@@TRANSACTION_API_VERSION':       '2021-08-09',
     '@@RINGPOOL_API_VERSION':          '2015-12-09',
     '@@PNAPI_VERSION':                 '2013-07-01',
     '@@SIGNAL_API_VERSION':            '2018-02-01'


### PR DESCRIPTION
https://invoca.atlassian.net/browse/STORY-9883

* Updated `Custom Data` docs to read `Marketing Data`
* Renamed file to `_marketing_data_params.rst`
* Updated references to `Custom Data` docs to `Marketing Data`

Note: I had some difficulties building the html for these docs locally.  Looks like we are using Python 2.7 (which is being deprecated) to create the virtual environment so this caused some trouble.
`sudo easy_install pip` did not work for me because it was attempting to install a later version that did not not support Python 2.7.

I had to run the following commands instead:
`rm -f /usr/local/bin/pip`
`sudo easy_install pip==20.3.4`
After this I was able to create a virtual environment and build the docs.

In the process of debugging I also noticed we are using an old version of Sphinx. Commands in our `config.py` setup have been deprecated for years. I'm curious if we will be upgrading our Python and/or Sphinx versioning for our documentation any time soon?

<!-- Each Pull Request should focus on a single API family -->

* I tried building the latest version on Read the Docs but it didn't pick up my changes. I believe this needs to be merged first

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
