### PR TITLE
STORY-9870 call activity tracking (to 2020-10-01):

### DIFF
--- a/source/api_documentation/network_integration/call_activity_tracking/index.rst
+++ b/source/api_documentation/network_integration/call_activity_tracking/index.rst
@@ -1,0 +1,51 @@
+Call Activity Tracking
+======================
+
+Manage call activity tracking for campaigns
+"""""""""""""""""""""""""""""""""""""""""""
+
+Call activity tracking can be set for a campaign to determine whether or not call activity should be tracked. The call activity will be tracked if the full condition is met.
+
+Set Call Activity Tracking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To conditionally track call activity, set ``"call_activity_tracking"`` to the tracking option you want.
+
+POST
+
+``https://invoca.net/api/@@CAMPAIGN_FEATURES_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>.json``
+
+Example Request Body
+
+.. code-block:: json
+
+  {
+    "ivr_tree": {
+      "call_activity_tracking": "NoTracking",
+      "root": {
+        "node_type": "Connect",
+        "destination_phone_number": "8056173768",
+        "destination_country_code": ""
+      }
+    }
+  }
+
+Conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+  :widths: 30 50 30
+  :header-rows: 1
+  :class: parameters
+
+  * - Option
+    - Details
+
+  * - NoTracking (Default)
+    - Default is NoTracking. When set to NoTracking, no IVR or call activity data will be tracked during the call.
+
+  * - PurgeActivityOnCallImport
+    - When set to PurgeActivityOnCallImport, IVR and call activity data will be tracked during the call for use while the call is happening but will be purged when the call finishes.
+
+  * - SaveActivityOnCallImport
+    - When set to SaveActivityOnCallImport, IVR and call activity data will be tracked during the call and will be saved in the Invoca platform after the call finishes.

--- a/source/api_documentation/network_integration/call_activity_tracking/index.rst
+++ b/source/api_documentation/network_integration/call_activity_tracking/index.rst
@@ -1,6 +1,8 @@
 Call Activity Tracking
 ======================
 
+For full details on creating and updating campaigns via the API, see <a href="advertiser_campaigns/index.html">Advertiser Campaigns</a>.
+
 Manage call activity tracking for campaigns
 """""""""""""""""""""""""""""""""""""""""""
 

--- a/source/api_documentation/network_integration/index.rst
+++ b/source/api_documentation/network_integration/index.rst
@@ -31,6 +31,7 @@ The API uses the following terms and their aliases:
    advertiser_affiliate_relationships/index
    networks/index
    promo_numbers/index
+   call_activity_tracking/index
    call_recording_condition/index
    prompt_recordings/index
    set_call_recorded_prompt/index


### PR DESCRIPTION
[STORY-9870: API To Change Campaign's Call Activity Tracking Option](https://ringrevenue.atlassian.net/browse/STORY-9870)

This change indicates that `call_activity_tracking` is supported in IVR trees for the advertiser campaign API (within the Network integration api family) for  API version `2019-05-01+`.

Please forgive any mistakes or something off-pattern here. This is my first `developer-docs` change. :)

Here's a PR linking to the related functionality being enabled in the `web` repo:

- https://github.com/Invoca/web/pull/16101

See also the PR which merges to `2019-05-01`:

- https://github.com/Invoca/developer-docs/pull/272

cc. @sstengele @rphammy @BMTTMC 

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
