### PR TITLE
STORY-10029: Add transcript API documentation page

### DIFF
--- a/source/api_documentation/call_api/_get_call_transcript_agent.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_agent.rst
@@ -1,0 +1,23 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript for the given call record `CUID-33` with just the agent included
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+     [
+       {
+        agent: "Which Color?, Okay I will look into that, Goodbye!"
+       }
+     ]

--- a/source/api_documentation/call_api/_get_call_transcript_agent.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_agent.rst
@@ -16,8 +16,8 @@
 
   .. code-block:: json
 
-     [
-       {
+    [
+      {
         agent: "Which Color?, Okay I will look into that, Goodbye!"
-       }
-     ]
+      }
+    ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller.rst
@@ -15,9 +15,9 @@
   Response Body:
 
   .. code-block:: json
-
-     [
-       {
+  
+    [
+      {
         caller: "Orange, Awesome thank you, Have a good one"
-       }
-     ]
+      }
+    ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller.rst
@@ -1,0 +1,23 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript for the given call record `CUID-33` with just the caller included
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=caller``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+     [
+       {
+        caller: "Orange, Awesome thank you, Have a good one"
+       }
+     ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
@@ -17,8 +17,6 @@
   .. code-block:: json
 
      [
-       {
-        agent: "Which Color?, Okay I will look into that, Goodbye!",
-        caller: "Orange, Awesome thank you, Have a good one"
-       }
+       { agent: "Which Color?, Okay I will look into that, Goodbye!" },
+       { caller: "Orange, Awesome thank you, Have a good one" }
      ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
@@ -15,8 +15,8 @@
   Response Body:
 
   .. code-block:: json
-
-     [
-       { agent: "Which Color?, Okay I will look into that, Goodbye!" },
-       { caller: "Orange, Awesome thank you, Have a good one" }
-     ]
+  
+    [
+      { agent: "Which Color?, Okay I will look into that, Goodbye!" },
+      { caller: "Orange, Awesome thank you, Have a good one" }
+    ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
@@ -1,0 +1,24 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript for the given call record `CUID-33` with both agent and caller included in a single block for each.
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent_caller_block``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+     [
+       {
+        agent: "Which Color?, Okay I will look into that, Goodbye!",
+        caller: "Orange, Awesome thank you, Have a good one"
+       }
+     ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
@@ -15,12 +15,12 @@
   Response Body:
 
   .. code-block:: json
-
-     [
-        { agent: "Which Color?" },
-        { caller: "Orange" },
-        { agent: "Okay I will look into that" },
-        { caller: "Awesome thank you" },
-        { agent: "Goodbye!" },
-        { caller: "Have a good one" }
-     ]
+  
+    [
+      { agent: "Which Color?" },
+      { caller: "Orange" },
+      { agent: "Okay I will look into that" },
+      { caller: "Awesome thank you" },
+      { agent: "Goodbye!" },
+      { caller: "Have a good one" }
+    ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
@@ -17,12 +17,10 @@
   .. code-block:: json
 
      [
-       {
-        agent: "Which Color?",
-        caller: "Orange"
-        agent: "Okay I will look into that",
-        caller: "Awesome thank you",
-        agent: "Goodbye!",
-        caller: "Have a good one"
-       }
+        { agent: "Which Color?" },
+        { caller: "Orange" },
+        { agent: "Okay I will look into that" },
+        { caller: "Awesome thank you" },
+        { agent: "Goodbye!" },
+        { caller: "Have a good one" }
      ]

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
@@ -1,0 +1,28 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript for the given call record `CUID-33` with both agent and caller included in the corresponding conversation order.
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent_caller_conversation``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+     [
+       {
+        agent: "Which Color?",
+        caller: "Orange"
+        agent: "Okay I will look into that",
+        caller: "Awesome thank you",
+        agent: "Goodbye!",
+        caller: "Have a good one"
+       }
+     ]

--- a/source/api_documentation/call_api/index.rst
+++ b/source/api_documentation/call_api/index.rst
@@ -9,10 +9,6 @@ The data returned depends on the request and query paramaters. To see which fiel
 
 :doc:`transcript_api`
 
-Please note, the documentation shows a superset of fields available. Your response may differ depending on the
-features enabled on the platform being accessed. Make a sample request to the API to identify the fields returned.
-
-
 .. toctree::
    :maxdepth: 2
    :hidden:

--- a/source/api_documentation/call_api/index.rst
+++ b/source/api_documentation/call_api/index.rst
@@ -1,0 +1,20 @@
+Call API
+================
+
+The Call API is accessible using the API credentials generated on the platform.
+
+.. raw:: html
+
+The data returned depends on your account type. To see which fields you will see, select an account type below.
+
+:doc:`transcript_api`
+
+Please note, the documentation shows a superset of fields available. Your response may differ depending on the
+features enabled on the platform being accessed. Make a sample request to the API to identify the fields returned.
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   transcript_api

--- a/source/api_documentation/call_api/index.rst
+++ b/source/api_documentation/call_api/index.rst
@@ -5,7 +5,7 @@ The Call API is accessible using the API credentials generated on the platform.
 
 .. raw:: html
 
-The data returned depends on your account type. To see which fields you will see, select an account type below.
+The data returned depends on the request and query paramaters. To see which fields you will see, select a request type below.
 
 :doc:`transcript_api`
 

--- a/source/api_documentation/call_api/transcript_api.rst
+++ b/source/api_documentation/call_api/transcript_api.rst
@@ -7,7 +7,7 @@ Transcripts
 URL
 ---
 
-The API follows REST conventions. Perform an HTTPS GET to the URL with the format in which you’d like to receive data. The following response formats are supported, where CUID-33 is the advertiser id.
+The API follows REST conventions. Perform an HTTPS GET to the URL with the format in which you’d like to receive data. The following response formats are supported, where CUID-33 is the call record id.
 
 .. list-table::
   :widths: 8 40

--- a/source/api_documentation/call_api/transcript_api.rst
+++ b/source/api_documentation/call_api/transcript_api.rst
@@ -1,0 +1,74 @@
+#####################
+Transcripts
+#####################
+
+.. include:: _rollup_message.rst
+
+URL
+---
+
+The API follows REST conventions. Perform an HTTPS GET to the URL with the format in which you’d like to receive data. The following response formats are supported, where CUID-33 is the advertiser id.
+
+.. list-table::
+  :widths: 8 40
+  :header-rows: 1
+  :class: parameters
+
+  * - Format
+    - Description and URL
+
+  * - json (default)
+    - Returns a JSON array of the transcript. `https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent`
+
+Authentication
+--------------
+
+The API uses OAuth to validate access. The OAuth Token can be passed in two ways. The first way is to pass the OAuth Token in the header of the request. The second is to pass the OAuth Token like any other query parameter. Please note that the OAuth Token is a required parameter.
+OAuth Tokens may be generated from the Manage API Credentials page.
+
+Query Parameters
+----------------
+
+The API takes the following optional query parameters:
+
+.. list-table::
+  :widths: 8 40
+  :header-rows: 1
+  :class: parameters
+
+  * - Parameter
+    - Description
+
+  * - transcript_format= (required)
+    - Dertimines the which format and transcripts are included, see response parameters below for information on each format.
+
+Response
+--------
+.. api_endpoint::
+   :verb: GET
+   :path: /call/transcript/&lt;call_record_id&gt?transcript_format=caller;
+   :description: Get a transcript of the call for just the caller
+   :page: get_call_transcript_caller
+
+.. api_endpoint::
+   :verb: GET
+   :path: /call/transcript/&lt;call_record_id&gt?transcript_format=agent;
+   :description: Get a transcript of the call for just the agent
+   :page: get_call_transcript_agent
+
+.. api_endpoint::
+   :verb: GET
+   :path: /call/transcript/&lt;call_record_id&gt?transcript_format=caller_agent_block;
+   :description: Get a transcript of the call as a block
+   :page: get_call_transcript_caller_agent_block
+
+.. api_endpoint::
+   :verb: GET
+   :path: /call/transcript/&lt;call_record_id&gt?transcript_format=caller_agent_conversation;
+   :description: Get a transcript of the call as a conversation
+   :page: get_call_transcript_caller_agent_conversation
+
+
+Endpoint:
+
+``https://mynetwork.invoca.net/call/transcript/<call_record_id>?transcript_format=<format>``

--- a/source/api_documentation/call_api/transcript_api.rst
+++ b/source/api_documentation/call_api/transcript_api.rst
@@ -40,7 +40,7 @@ The API takes the following optional query parameters:
     - Description
 
   * - transcript_format= (required)
-    - Dertimines the which format and transcripts are included, see response parameters below for information on each format.
+    - Determines what format the transcripts are returned as, see response parameters below for information on each format.
 
 Response
 --------

--- a/source/api_documentation/index.rst
+++ b/source/api_documentation/index.rst
@@ -20,6 +20,9 @@ allocates a dynamic, trackable promo phone number from a RingPool (designed to h
 :doc:`signal_api/index` -
 used to report signals that occur on a specific call (transaction).
 
+:doc:`call_api/index` -
+used to pull transcript information for a specific call (transcript).
+
 
 The Transactions API and Network Integration API are accessible using the API credentials generated on the platform. See :doc:`manage_api_credentials` for more information.
 
@@ -47,3 +50,4 @@ The RingPool wizard includes a section showing the correct API URL for your orga
    ringpool
    bulk_ringpool_api
    signal_api/index
+   call_api/index

--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,6 +1,6 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2021-08-09'
+COMMON_VERSION = '2021-09-07'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':           '2018-11-01',
@@ -9,5 +9,6 @@ VERSIONS = {
     '@@TRANSACTION_API_VERSION':       '2021-08-09',
     '@@RINGPOOL_API_VERSION':          '2015-12-09',
     '@@PNAPI_VERSION':                 '2013-07-01',
-    '@@SIGNAL_API_VERSION':            '2018-02-01'
+    '@@SIGNAL_API_VERSION':            '2018-02-01',
+    '@@CALL_API_VERSION':              '2021-09-07'
 }


### PR DESCRIPTION
[JIRA TICKET](https://invoca.atlassian.net/browse/STORY-10029)

This documentation update is focusing on our new Transcript API that details how to access the transcripts for a given call. As part of this change we are adding a new primary navigation section "Call Api" and within that adding the "Transcripts" page. We added this new section as looking forward we will also want to add the "Recording Api" section in this as well, but that is more future work.

The Transcript API itself is fairly simple and modeled the page similar to the Transcation API but using the expandable API rows to display examples of our different Query Parameters. Currently our API only has one required query parameter `transcript_format` and only returns in JSON format, so a lot of the tables have been reduced to match the expectations of the API.

To confirm that this documentation is correct the corresponding tickets that add in the functionality for this update can be found here.
- https://invoca.atlassian.net/browse/STORY-10028

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
