### PR TITLE
update doc_versions.py to reflect latest version in web

### DIFF
--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,14 +1,14 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2021-09-07'
+COMMON_VERSION = '2020-10-01'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':           '2018-11-01',
     '@@CAMPAIGN_FEATURES_API_VERSION': '2019-05-01',
     '@@CONVERSION_API_VERSION':        '2014-04-15',
-    '@@TRANSACTION_API_VERSION':       '2021-08-09',
+    '@@TRANSACTION_API_VERSION':       '2020-10-01',
     '@@RINGPOOL_API_VERSION':          '2015-12-09',
     '@@PNAPI_VERSION':                 '2013-07-01',
     '@@SIGNAL_API_VERSION':            '2018-02-01',
-    '@@CALL_API_VERSION':              '2021-09-07'
+    '@@CALL_API_VERSION':              '2020-10-01'
 }


### PR DESCRIPTION
Update latest version to read "2020-10-01", since this version is available in web.
https://github.com/Invoca/web/blob/2b534e201410a549e4c51aec1f083e90d178723d/lib/api/version_format_checker.rb#L11-L25

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
