### PR TITLE
STORY-10745: Updates for new node types and relevant params

### DIFF
--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -269,9 +269,7 @@ Node Parameters and Usage
 
       \*destination_extension
 
-    -
-
-      Forwards the call to a selected phone number after optionally reading a prompt.
+    - Forwards the call to a selected phone number after optionally reading a prompt.
 
   * - EndCall
     - prompt
@@ -294,11 +292,42 @@ Node Parameters and Usage
 
   * - VerifyLocation
     - prompt
-    - Prompt the caller to verify the guessed location or confirm through input. Useful if geographical data is important or useful in a condition node.
+    - Prompts the caller to verify the guessed location or confirm through input. Useful if geographical data is important or useful in a condition node.
 
   * - DynamicRoute (beta - read only)
     - \*dynamic_route_destination
     - Forwards the call to a destination that is extracted from a custom data field specified in dynamic_route_destination. The destination must be a phone number or if you are SIP integrated, can be a string that is routable by your SIP infrastructure.
+
+  * - AnyKeyPress
+    - \*prompt
+
+    - Allows the caller to make any keypress to continue the call.
+
+  * - NumberQuestion
+    - \*prompt
+
+      \*number_question_type
+
+      confirm_response_enabled
+
+      error_prompt_disabled
+
+      custom_error_prompt_text
+
+      caller_response_custom_data_partner_name
+
+    - Allows the caller to respond to a prompt with numerical data (e.g. Phone Number, Date) and validates it if applicable. The caller's response may be saved to a marketing data field.
+
+  * - YesOrNo
+    - \*prompt
+
+      confirm_response_enabled
+
+      error_prompt_disabled
+
+      custom_error_prompt_text
+
+    - Allows the caller to respond to a prompt that will either have a yes or no answer. The caller's response determines how the call will continue.
 
 Node Details
 
@@ -323,7 +352,7 @@ Node Details
     - May have exactly 1 child node. After accepting or declining the promotional sms, the child node will be executed. To accept the promotional sms, the user must push 9 on the phone (this should be added as part of the prompt). Only numbers recognized as mobile phones will be offered the sms option.
 
   * - Condition
-    - May have exactly 2 child nodes. If the conditions are met, the first child is executed. If they are not met then the second child plays. See the conditions section and examples below for details on valid conditions.
+    - May have exactly 2 child nodes. If the conditions are met, the first child node is executed. If they are not met then the second child node is executed. See the conditions section and examples below for details on valid conditions.
 
   * - NearestBranch
     - May have exactly 1 child node. The caller will be prompted to verify their location prior to forwarding the call. If no branch is within ‘radius_miles’ of the caller then the child node will be executed.
@@ -333,6 +362,15 @@ Node Details
 
   * - DynamicRoute (beta - read only)
     - May have exactly 1 child node. We will evaluate the custom data field value specified on this node's dynamic_route_destination. With non-SIP integration, if the extracted value is a valid phone number and the destination phone number is in an allowed region given your settings, we will play the prompt and transfer the call, otherwise the child node will be executed without the prompt. When SIP integrated, we also allow transferring to any string (such as an extension), in which case the destination should be routable by your SIP infrastructure.
+
+  * - AnyKeyPress
+    - May have exactly 2 child nodes. If any keypress is made, the first child node is executed. If no keypress is made, then the second child node is executed.
+
+  * - NumberQuestion
+    - May have exactly 1 child node. Requires a question type to be selected (e.g. Phone Number, Date). The prompt will play before the caller answers the question. The answer may be saved in a marketing data field.
+
+  * - YesOrNo
+    - May have exactly 2 child nodes. If a keypress of 1 is made, the first child node is executed. If a kepyress of 2 is made, the second child node is executed. If speech recognition is enabled, the caller may also respond verbally with a "yes" or "no", respectively.
 
 Parameter Details
 
@@ -345,9 +383,21 @@ Parameter Details
     - Type
     - Value
 
+  * - caller_response_custom_data_partner_name
+    - String
+    - The partner name of the custom data field that will be used to save the caller's response to the NumberQuestion prompt.
+
   * - condition
     - String
     - The boolean condition that decided if the first or second child will be executed in a condition node.
+
+  * - confirm_response_enabled
+    - Boolean
+    - When enabled, the system will read back the caller's answer to the prompt and ask for confirmation. The caller can press 1 to confirm or 2 refute. If speech recogition is enabled, they may also respond verbally with a "yes" or "no", respectively.
+
+  * - custom_error_prompt_text
+    - String
+    - Custom text that will be played to the caller when they make an invalid keypress.
 
   * - destination_country_code
     - String
@@ -365,6 +415,18 @@ Parameter Details
     - Strings
     - The custom data field partner name you want to use as the destination in a dynamic route node. Typically a phone number in e164 format.
 
+  * - error_prompt_disabled
+    - Boolean
+    - If set to true, no error sound or prompt will play when a caller makes an invalid keypress. If enabled, when a caller makes an invalid keypress, an error sound will play, or you can optionally define a custom error prompt via the parameter custom_error_prompt_text.
+
+  * - keypress_failover_type
+    - String
+    - The failover type to use for a child node of a Menu. "Wrong" for when a wrong keypress is pressed by the caller on any attempt for the parent menu (shown in reporting as keypress "W"). "None" for when there is no keypress by the caller for all attempts for the parent menu (shown in reporting as keypress "N"). Omit this parameter for normal keypresses. See example below.
+
+  * - number_question_type
+    - String
+    - The type of question you want to ask as part of the NumberQuestion node type. This may be "Digits", "Number", "Phone Number" "Date", "Currency", "Time", or Zip Code".
+
   * - prompt
     - String
     - The text that will be read before a nodes action occurs. An empty string will result in no prompt being read, and the following action will occur immediately.
@@ -380,10 +442,6 @@ Parameter Details
   * - sms_promo_sender
     - String
     - The email address that will be shown in the sms. This defaults to sms@invoca.net.
-
-  * - keypress_failover_type
-    - String
-    - The failover type to use for a child node of a Menu. "Wrong" for when a wrong keypress is pressed by the caller on any attempt for the parent menu (shown in reporting as keypress "W"). "None" for when there is no keypress by the caller for all attempts for the parent menu (shown in reporting as keypress "N"). Omit this parameter for normal keypresses. See example below.
 
 Conditions
 

--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -343,7 +343,7 @@ Node Details
     - Details
 
   * - Menu
-    - Can have 1‐9 child nodes, with each child corresponding to the 1‐9 buttons. At the end of the child list, it can also optionally have failover child nodes designated by a node with a keypress_failover_type parameter (see example below). If speech recognition is enabled, the caller may also respond verbally with their menu choice by saying the designated phrase.
+    - Can have 1‐9 child nodes, with each child corresponding to the 1‐9 buttons. At the end of the child list, it can also optionally have failover child nodes designated by a node with a keypress_failover_type parameter (see example below). If speech recognition is enabled, the caller may also respond verbally with their menu choice (i.e. "one" for 1, and "two" for 2).
 
   * - Connect
     - May not have any children. The prompt will be read before connecting to the provided phone number.

--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -258,6 +258,9 @@ Node Parameters and Usage
 
   * - Menu
     - \*prompt
+
+      confirm_response_enabled
+
     - Allows the caller to select from up to 9 choices (e.g. choosing a department, selecting a language, etc).
 
   * - Connect
@@ -301,7 +304,7 @@ Node Parameters and Usage
   * - AnyKeyPress
     - \*prompt
 
-    - Allows the caller to make any keypress to continue the call.
+    - Prompts the caller to make any keypress to continue the call.
 
   * - NumberQuestion
     - \*prompt
@@ -316,7 +319,7 @@ Node Parameters and Usage
 
       caller_response_custom_data_partner_name
 
-    - Allows the caller to respond to a prompt with numerical data (e.g. Phone Number, Date) and validates it if applicable. The caller's response may be saved to a marketing data field.
+    - Prompts the caller to respond with a multi-digit number (e.g. Phone Number, Date) and validates it if applicable. The caller's response may be saved to a marketing data field.
 
   * - YesOrNo
     - \*prompt
@@ -327,7 +330,7 @@ Node Parameters and Usage
 
       custom_error_prompt_text
 
-    - Allows the caller to respond to a prompt that will either have a yes or no answer. The caller's response determines how the call will continue.
+    - Prompts the caller to respond with either a yes or no answer. The caller's response determines how the call will continue.
 
 Node Details
 
@@ -340,7 +343,7 @@ Node Details
     - Details
 
   * - Menu
-    - Can have 1‐9 child nodes, with each child corresponding to the 1‐9 buttons. At the end of the child list, it can also optionally have failover child nodes designated by a node with a keypress_failover_type parameter. See example below.
+    - Can have 1‐9 child nodes, with each child corresponding to the 1‐9 buttons. At the end of the child list, it can also optionally have failover child nodes designated by a node with a keypress_failover_type parameter (see example below). If speech recognition is enabled, the caller may also respond verbally with their menu choice by saying the designated phrase.
 
   * - Connect
     - May not have any children. The prompt will be read before connecting to the provided phone number.
@@ -367,10 +370,10 @@ Node Details
     - May have exactly 2 child nodes. If any keypress is made, the first child node is executed. If no keypress is made, then the second child node is executed.
 
   * - NumberQuestion
-    - May have exactly 1 child node. Requires a question type to be selected (e.g. Phone Number, Date). The prompt will play before the caller answers the question. The answer may be saved in a marketing data field.
+    - May have exactly 1 child node. Requires a question type to be selected (e.g. Phone Number, Date). The prompt will play before the caller answers the question. The answer may be saved in a marketing data field. At the end of the child list, this node type can also optionally have failover child nodes, designated by a node with a keypress_failover_type parameter (see example below).
 
   * - YesOrNo
-    - May have exactly 2 child nodes. If a keypress of 1 is made, the first child node is executed. If a kepyress of 2 is made, the second child node is executed. If speech recognition is enabled, the caller may also respond verbally with a "yes" or "no", respectively.
+    - May have exactly 2 child nodes. If a keypress of 1 is made, the first child node is executed. If a kepyress of 2 is made, the second child node is executed. If speech recognition is enabled, the caller can also say "yes" for 1 and "no" for 2. At the end of the child list, this node type can also optionally have failover child nodes, designated by a node with a keypress_failover_type parameter (see example below).
 
 Parameter Details
 
@@ -393,11 +396,11 @@ Parameter Details
 
   * - confirm_response_enabled
     - Boolean
-    - When enabled, the system will read back the caller's answer to the prompt and ask for confirmation. The caller can press 1 to confirm or 2 refute. If speech recogition is enabled, they may also respond verbally with a "yes" or "no", respectively.
+    - When enabled, the system will read back the caller's answer to the prompt and ask for confirmation. The caller can press 1 for "yes" and 2 for "no". If speech recogition is enabled, callers can also confirm their response by saying "yes" or "no".
 
   * - custom_error_prompt_text
     - String
-    - Custom text that will be played to the caller when they make an invalid keypress.
+    - Custom text that will be played to the caller when they provide an invalid response or no response.
 
   * - destination_country_code
     - String
@@ -417,7 +420,7 @@ Parameter Details
 
   * - error_prompt_disabled
     - Boolean
-    - If set to true, no error sound or prompt will play when a caller makes an invalid keypress. If enabled, when a caller makes an invalid keypress, an error sound will play, or you can optionally define a custom error prompt via the parameter custom_error_prompt_text.
+    - If set to true, no error sound or prompt will play when the caller provides an invalid response or no response. If set to false, when the caller provides an invalid response or no response, an error sound will play, or you can optionally define a custom error prompt via the parameter custom_error_prompt_text.
 
   * - keypress_failover_type
     - String
@@ -425,7 +428,7 @@ Parameter Details
 
   * - number_question_type
     - String
-    - The type of question you want to ask as part of the NumberQuestion node type. This may be "Digits", "Number", "Phone Number" "Date", "Currency", "Time", or Zip Code".
+    - The type of question you want to ask as part of the NumberQuestion node type. This may be "Digits", "Number", "PhoneNumber", "Date", "Currency", "Time", or "ZipCode".
 
   * - prompt
     - String

--- a/source/api_documentation/network_integration/automated_speech_recognition/index.rst
+++ b/source/api_documentation/network_integration/automated_speech_recognition/index.rst
@@ -1,0 +1,44 @@
+Speech Recognition
+======================
+
+For full details on creating and updating campaigns via the API, see :doc:`Advertiser Campaigns <../advertiser_campaigns/index>`.
+
+Manage speech recognition for campaigns
+"""""""""""""""""""""""""""""""""""""""""""
+
+Speech recognition can be set for a campaign to determine whether or not the caller may respond verbally to prompts in the IVR. When set to true, the caller can respond both verbally and with keypresses.
+
+Set Speech Recognition
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To enable speech recognition for a campaign, set ``"asr_enabled"`` to true.
+
+POST
+
+``https://invoca.net/api/@@CAMPAIGN_FEATURES_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>.json``
+
+Example Request Body
+
+.. code-block:: json
+
+  {
+    "ivr_tree": {
+      "asr_enabled": true,
+      "root": {
+        "node_type": "YesOrNo",
+        "prompt": "Are you having a good day?",
+        "children": [
+            {
+                "node_type": "Connect",
+                "destination_phone_number": "8007381560",
+                "destination_country_code": "1"
+            },
+            {
+                "node_type": "Connect",
+                "destination_phone_number": "8007381560",
+                "destination_country_code": "1"
+            }
+        ]
+      }
+    }
+  }

--- a/source/api_documentation/network_integration/index.rst
+++ b/source/api_documentation/network_integration/index.rst
@@ -38,4 +38,5 @@ The API uses the following terms and their aliases:
    whisper_prompts/index
    custom_challenge_prompts/index
    custom_ivr_error_prompts/index
+   automated_speech_recognition/index
    ringpools/index


### PR DESCRIPTION
[STORY-10745](https://invoca.atlassian.net/browse/STORY-10745)

### Summary

- Added `AnyKeyPress`, `NumberQuestion`, and `YesOrNo` node types and relevant parameters to the [Advertiser Campaign IVRs](https://developers.invoca.net/en/2020-10-01/api_documentation/network_integration/advertiser_campaigns/index.html#advertiser-campaign-ivrs) section of the NIAPI docs.

### Open Questions

- On the ticket, a note was made about adding documentation speech recognition. Since it doesn't really fit anywhere in the existing [Advertiser Campaign IVRs](https://developers.invoca.net/en/2020-10-01/api_documentation/network_integration/advertiser_campaigns/index.html#advertiser-campaign-ivrs), I think it needs its own page, similar to [Custom Wrong/No Keypress Error Prompt](https://developers.invoca.net/en/2020-10-01/api_documentation/network_integration/custom_ivr_error_prompts/index.html). That's a very large undertaking and since ASR isn't fully fleshed out yet, I'm not sure it make sense to do that at this time. Thouhts?

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)

<img width="908" alt="Screen Shot 2021-12-06 at 3 44 35 PM" src="https://user-images.githubusercontent.com/26881159/144941210-a2ed03b4-7598-4593-b474-ee460569c489.png">
<img width="890" alt="Screen Shot 2021-12-06 at 3 44 41 PM" src="https://user-images.githubusercontent.com/26881159/144941173-1f9a8757-fd6b-4142-b77b-f9d477cec953.png">
<img width="892" alt="Screen Shot 2021-12-06 at 3 44 48 PM" src="https://user-images.githubusercontent.com/26881159/144941130-a9ddba47-93d6-4c58-a01c-1b72466959a8.png">
<img width="1479" alt="Screen Shot 2021-12-06 at 3 45 01 PM" src="https://user-images.githubusercontent.com/26881159/144940511-31450e14-5246-436d-a68d-62edcd9cc4ec.png">


