### PR TITLE
STORY-11010 update ringpool docs for fill_immediately flag

### DIFF
--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -47,6 +47,10 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
     - A phone number to be associated with the RingPool.
     - When using Destinations UI or the forward to destination IVR node, this number will be used.
 
+  * - fill_immediately
+    - boolean
+    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size if numbers are available. When false, the pool is initially filled at 10% capacity. Defaults to false.
+
 Endpoint:
 
 ``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>/ring_pools/<ring_pool_id_from_network>.json``
@@ -141,6 +145,10 @@ Content Type: application/json
   * - preferred
     - boolean
     - true or false.  Selects this RingPool if the advertiser has multiple RingPools for the campaign and the web integration code does not specifiy which pool to use.
+
+  * - fill_immediately
+    - boolean
+    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size if numbers are available. When false, the pool is initially filled at 10% capacity. Defaults to false.
 
   * - local_center
     - hash

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -49,7 +49,7 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
 
   * - fill_immediately
     - boolean
-    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size if numbers are available. When false, the pool is initially filled at 10% capacity. Defaults to false.
+    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size, if numbers are available. When false, the pool will initially fill at 10% capacity to conserve phone number usage. The ringpool will increase phone numbers based on ringpool autoscaling settings and traffic volume.
 
 Endpoint:
 
@@ -148,7 +148,7 @@ Content Type: application/json
 
   * - fill_immediately
     - boolean
-    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size if numbers are available. When false, the pool is initially filled at 10% capacity. Defaults to false.
+    - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size, if numbers are available. When false, the pool will initially fill at 10% capacity to conserve phone number usage. The ringpool will increase phone numbers based on ringpool autoscaling settings and traffic volume.
 
   * - local_center
     - hash


### PR DESCRIPTION
https://invoca.atlassian.net/browse/STORY-11010

Adds fill_immediately flag to Network Integration Ringpools API allowing users to fully preallocate new ringpools

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)

**Change applies to 2010-10-01 and 2019-05-01 versions only**
2019-05-01 PR: https://github.com/Invoca/developer-docs/pull/280
2020-10-01 PR: https://github.com/Invoca/developer-docs/pull/279