### PR TITLE
Web 5868 fix format transcript api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The [developer portal](http://developers.invoca.net) contains public documentati
 1. Clone this repo
 2. Run the following commands:
 ```
-sudo easy_install pip
+# note that python version used is 2.7
+sudo easy_install pip==20.3.4 # must specify this pip version
 sudo pip install virtualenv
 virtualenv venv
 source venv/bin/activate

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_block.rst
@@ -6,7 +6,7 @@
 
   Endpoint:
 
-  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent_caller_block``
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=caller_agent_block``
 
   Format: application/json
 

--- a/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_caller_agent_conversation.rst
@@ -6,7 +6,7 @@
 
   Endpoint:
 
-  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=agent_caller_conversation``
+  ``https://mynetwork.invoca.net/call/transcript/CUID-33?transcript_format=caller_agent_conversation``
 
   Format: application/json
 


### PR DESCRIPTION
https://invoca.atlassian.net/browse/WEB-5868
fix incorrect `transcript_format` value listed on the transcript api page. Some values were incorrectly listed as `agent_caller_block` and `agent_caller_conversation`, and have been fixed to display the correct values of `caller_agent_block` and `caller_agent_conversation`

update readme's `getting started` to:
* specify python version 
*  include desired pip version ([context for changes made](https://invoca.slack.com/archives/C023NRFGFFU/p1628208897114200?thread_ts=1628208391.113700&cid=C023NRFGFFU))

<!-- Each Pull Request should focus on a single API family -->

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
