### PR TITLE
KB-405: marking conversion reporting pages as deprecated

### DIFF
--- a/source/api_documentation/conversion_reporting.rst
+++ b/source/api_documentation/conversion_reporting.rst
@@ -1,11 +1,29 @@
-Conversion Reporting
+Conversion Reporting (Deprecated)
 ====================
+
+.. raw:: html
+
+  <div style="margin-bottom: 20px; padding: 15px; background-color: #fff3cd; color: #333;"><p>
+    <b>Notice:</b>
+    <a href="https://developers.invoca.net/en/latest/api_documentation/signal_api/index.html">Signal API</a> is now the supported way for reporting that a sale or other post call event occurred on calls.
+    The Conversion Reporting API is deprecated and no longer available for new accounts.</p>
+  </div>
 
 The Conversion Reporting API (formerly referred to as the “Call Center” or “Sales Reporting” API) is used to report completed order information (or other conversion events) from a server back into the platform.
 Reporting order information through the API allows advertisers to compensate publishers for sales that convert over the phone (or on the web).
 Additionally, Advertiser Direct campaigns using the Conversion Reporting API with search campaigns can report back revenue generated for each phone call so that search bids can be optimized.
 
-Before using the Conversion Reporting API, request credentials from questions@invoca.com
+For existing customers looking for deprecated documentation on the conversion pixel and email approach to reporting conversions, see these pages:
+
+:doc:`conversion_reporting_email`
+
+:doc:`conversion_reporting_pixel`
+
+Authentication
+-------------------
+
+The Conversion Reporting API requires specific credentials and a conversion reporting ID for the URL. Note: creating new credentials is no longer supported.
+Please use the :doc:`signal_api/index` instead.
 
 Client API Wrappers
 -------------------

--- a/source/api_documentation/conversion_reporting_email.rst
+++ b/source/api_documentation/conversion_reporting_email.rst
@@ -1,5 +1,14 @@
-Conversion Reporting Email
+Conversion Reporting Email (Deprecated)
 ==========================
+
+.. raw:: html
+
+  <div style="margin-bottom: 20px; padding: 15px; background-color: #fff3cd; color: #333;"><p>
+    <b>Notice:</b>
+    <a href="https://developers.invoca.net/en/latest/api_documentation/signal_api/index.html">Signal API</a> or
+    <a href="https://invoca.force.com/community/s/article/Reporting-Call-Conversions-via-Signal-File-Upload-or-Signal-API">Signal File Upload</a> is now the supported way for reporting that a sale or other post call event occurred on calls.
+    Conversion Reporting API and Email ingestion is deprecated and no longer available for new accounts.
+  </p></div>
 
 A legacy performance feature that is only used by customers running pay-per-call campaigns.  It provides the ability to payout on a conversion event that occurs on the call, typically helps advertisers to encourage the highest quality/caller intent calls. Conversion events can be reported using an email message with an attached CSV file.
 

--- a/source/api_documentation/conversion_reporting_pixel.rst
+++ b/source/api_documentation/conversion_reporting_pixel.rst
@@ -1,5 +1,14 @@
-Conversion Reporting Pixel
+Conversion Reporting Pixel (Deprecated)
 ==========================
+
+.. raw:: html
+
+  <div style="margin-bottom: 20px; padding: 15px; background-color: #fff3cd; color: #333;"><p>
+    <b>Notice:</b>
+    <a href="https://developers.invoca.net/en/latest/api_documentation/signal_api/index.html">Signal API</a> or
+    <a href="https://invoca.force.com/community/s/article/Reporting-Call-Conversions-via-Signal-File-Upload-or-Signal-API">Signal File Upload</a> is now the supported way for reporting that a sale or other post call event occurred on calls.
+    Conversion Reporting API and Web Pixel is deprecated and no longer available for new accounts.
+  </p></div>
 
 A conversion pixel is placed on an advertiser’s web page to report a conversion event that triggers payouts on the platform. Typically, the pixel is placed on a shopping cart confirmation page or lead form thank you page. The conversion pixel is for online traffic only and cannot match to your call data.
 

--- a/source/api_documentation/index.rst
+++ b/source/api_documentation/index.rst
@@ -11,11 +11,11 @@ supports the replication and synchronization of advertiser, publisher and campai
 :doc:`conversion_reporting` -
 provides the ability to report completed order information (or other conversion events) from a server back into the platform.
 
-:doc:`ringpool` -
-allocates a dynamic, trackable promo phone number from a RingPool.
-
 :doc:`bulk_ringpool_api` -
 allocates a dynamic, trackable promo phone number from a RingPool (designed to handle a high volume of requests per second).
+
+:doc:`ringpool` -
+allocates a dynamic, trackable promo phone number from a RingPool (no longer recommended).
 
 :doc:`signal_api/index` -
 used to report signals that occur on a specific call (transaction).
@@ -43,11 +43,9 @@ The RingPool wizard includes a section showing the correct API URL for your orga
 
    manage_api_credentials
    network_integration/index
-   conversion_reporting
-   conversion_reporting_pixel
-   conversion_reporting_email
    transactions_api/index
-   ringpool
    bulk_ringpool_api
+   ringpool
    signal_api/index
    call_api/index
+   conversion_reporting

--- a/source/api_documentation/ringpool.rst
+++ b/source/api_documentation/ringpool.rst
@@ -1,4 +1,4 @@
-Ringpool
+Ringpool API (Legacy)
 ========
 
 The RingPool API allocates a dynamic, trackable promo phone number from a RingPool. A valid call to the RingPool API returns a promo number and a formatted click-through URL.


### PR DESCRIPTION
* Also removed Conversion Reporting Pixel and Conversion Reporting Email from left index (they are linked from the Conversion Reporting API page now)
* Indicated RingPool API as legacy and moved below Bulk RingPool API (the preferred way to get dynamic allocation)

Plan was to only do these changes on the latest version of docs, but open to also backporting this to previous versions if we think that is best.

Demo video:
https://drive.google.com/file/d/1DyH83o6hh5MsNyP_N2lGsJsjZzbDcowF/view?usp=sharing

Preview URL:
https://developers.invoca.net/en/2020-10-01_deprecate_conv_reporting/api_documentation/index.html

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
