### PR TITLE
STORY-11055:  External Call API Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ html/
 *.tmp
 src/
 .vscode/settings.json
+.python-version

--- a/source/api_documentation/call_ingestion_api/_create_call.rst
+++ b/source/api_documentation/call_ingestion_api/_create_call.rst
@@ -10,7 +10,7 @@
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json``
 
   Request Body:
 
@@ -47,7 +47,7 @@
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json``
 
   Request Body:
 

--- a/source/api_documentation/call_ingestion_api/_create_call.rst
+++ b/source/api_documentation/call_ingestion_api/_create_call.rst
@@ -59,7 +59,6 @@
         "start_time": "2016-08-08 11:03:31 -0700",
         "destination_phone_number": 9093900003,
         "calling_phone_number": 8779257383,
-        "duration_in_seconds": 14,
         "advertiser_campaign_id_from_network": 85,
         "call_direction": "inbound",
         "recording_url": "<CALL RECORDING URL>"
@@ -67,13 +66,11 @@
       "signals": [
         {
           "name": "sale",
-          "value": 1,
-          "revenue": 100
+          "value": 1
         },
         {
           "name": "quote",
-          "value": 1,
-          "revenue": 1
+          "value": 1
         }
       ],
       "custom_data": [

--- a/source/api_documentation/call_ingestion_api/_create_call.rst
+++ b/source/api_documentation/call_ingestion_api/_create_call.rst
@@ -1,0 +1,100 @@
+
+
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  All of these examples use ``POST`` requests, but we will also accept ``PUT`` requests with the same request format.
+
+  Example of creating a call with all required fields populated:
+
+  Endpoint:
+
+  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+
+  Request Body:
+
+  .. code-block:: json
+
+    {
+      "call": {
+        "external_call_unique_id": "100002",
+        "start_time": "2016-02-03 09:30:00 AM",
+        "destination_phone_number": 2165388265,
+        "calling_phone_number": 8779257383,
+        "advertiser_campaign_id_from_network": 85,
+        "call_direction": "inbound",
+        "recording_url": "<CALL RECORDING URL>"
+      },
+      "oauth_token": "<YOUR OAUTH TOKEN>"
+    }
+
+  Response Code: 201
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+      "cuid": "<NEW_CUID>"
+    }
+
+  .. raw:: html
+
+    <hr>
+
+  Example of creating a call with all available fields populated (including Signals and Custom Data):
+
+  Endpoint:
+
+  ``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+
+  Request Body:
+
+  .. code-block:: json
+
+    {
+      "call": {
+        "external_call_unique_id": "123ABC",
+        "start_time": "2016-08-08 11:03:31 -0700",
+        "destination_phone_number": 9093900003,
+        "calling_phone_number": 8779257383,
+        "duration_in_seconds": 14,
+        "advertiser_campaign_id_from_network": 85,
+        "call_direction": "inbound",
+        "recording_url": "<CALL RECORDING URL>"
+      },
+      "signals": [
+        {
+          "name": "sale",
+          "value": 1,
+          "revenue": 100
+        },
+        {
+          "name": "quote",
+          "value": 1,
+          "revenue": 1
+        }
+      ],
+      "custom_data": [
+        {
+          "name": "channel",
+          "value": "Paid Search"
+        },
+        {
+          "name": "line_of_business",
+          "value": "Social"
+        }
+      ],
+      "oauth_token": "<YOUR OAUTH TOKEN>"
+    }
+
+  Response Code: 201
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+      "cuid": "<NEW_CUID>"
+    }

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -1,0 +1,297 @@
+Call Ingestion API
+=================
+
+The Call Ingestion API is used to submit call details along with a recording URL for calls that were not live-connected and routed through the Invoca Telephony platform.
+
+Calls submitted through this API are available to all post-call processing systems. This includes the Invoca transcription engine, Signal AI, as well as the Dashboard and Reporting system. 
+
+Invoca post-call processing services are applied to calls based on network and campaign settings.  The campaign for the call is determined by the *advertiser_campaign_id_from_network* parameter in the API.
+
+Additionally, Signals and Custom Data related to the call can be sumbitted during the initial call ingestion step.  Please note that Signals and Custom Data can also be applied in the future using the :doc:`../signal_api/index`.
+
+Signals can be any boolean value (e.g. sale, quote, etc), and Custom Data can be any alpha-numeric value (e.g. account type, customer quality score, etc).
+
+Response Codes
+--------------
+
+Remember to check the HTTP status code returned. This helps greatly when debugging.
+
+.. list-table::
+  :widths: 8 40
+  :header-rows: 1
+  :class: parameters
+
+
+  * - Status Code
+    - Meaning
+
+  * - 201 Created
+    - A new call creation request was successfully created.
+
+  * - 202 Accepted
+    - The call creation request has already been received and is currently being processed.
+
+  * - 400 Bad Request
+    - Attempted to make a request with an invalid API Version for route. Check the error message for any neccessary corrections
+
+  * - 401 Not Authorized
+    - Invalid or missing oauth token.
+
+  * - 403 Forbidden
+    - Attempted to access an invalid resource or provided invalid data. Check the errors object in the response.
+
+  * - 409 Conflict
+    - The **external_call_unique_id** in the request has already been used.  Please contact the Invoca support team at questions@invoca.com for further assistance.
+
+Request Parameters
+------------------
+
+Passed in “application/json” format.
+
+**Call Parameters**
+
+These are the call datails used when creating the call in the Invoca platform.
+
+    **Required**
+
+    `external_call_unique_id` The unique ID of the call in the system fom the external system.  This field is required to be unique across all calls within a network that are submitted from external sources.
+
+    `start_time` This is the date and time when the call started on the call origination platform.  Please see the **Timestamp Formats** section below for descriptions of supported timestamps.
+
+    `destination_phone_number` DNIS in E.164 format +country national_number; example: ‘+18885551212’. UK and Spanish numbers are also supported. Their country codes are +44 and +34 respectively.
+
+    `calling_phone_number` ANI in E.164 format +country national_number; example: ‘+18885551212’.
+
+    `advertiser_campaign_id_from_network` ID from network field on advertiser campaign; only calls within this advertiser campaign will be considered (campaign must be in the organization accessed via API).
+
+    `call_direction` The direction of the call flow.  Accepted values: *inbound* or *outbound*.
+
+    `recording_url` The URL to the call recording. Please see the **Supported Recording Formats** and **Supported Recording Access Options** sections for more details.
+    
+-----
+
+**Signal Parameters**
+
+Used to create the fields of a signal. The Signal name provided in a request **must** already exist in your **Signal AI configuration**.
+
+    **Required**
+
+    `name` The name describing the signal event. For reporting a sale happened on a call, “Sale” is recommended.
+    Other examples include “Free Trial”, “2yr Subscription”, “Cancellation.”
+    This can be used elsewhere in the system and should be a small list of values meaningful to your organization.
+    Names are matched case-insensitively, but we will preserve and use the casing of the first time the signal name is reported.
+
+    **Optional**
+
+    `value` True or false as to whether the signal was met or not. Defaults to true if not passed. Can be a string ‘true’ or ‘false’, or 1 (true) or 0 (false), Yes (true), or No (false). These values are not case sensitive.
+
+------
+
+**Custom Data Parameters**
+
+Apply Custom Data values to a call based on your Custom Data configuration.
+
+The Custom Data Fields provided in a request **must** already exist in your `Custom Data Configuration <https://www2.invoca.net/customer_data_dictionary/home>`_
+
+    **Required**
+
+    `name` The Partner (API) Name of the Custom Data Field you want to apply a value to. Visit your `Custom Data Management Page <https://www2.invoca.net/customer_data_dictionary/home>`_ to view your available Custom Data Fields.
+
+    `value` The value you would like to apply to the associated Custom Data Field for this call.
+
+------
+
+**Additional Parameters**
+
+    **Required**
+
+    `oauth_token` API token for authentication. Can be specified in the body or header of the request.
+
+Endpoint:
+
+``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+
+.. api_endpoint::
+  :verb: POST
+  :path: /transactions/create
+  :description: Create a new call in the Invoca platform.
+  :page: create_call
+
+
+
+Timestamp Formats
+-------------------------------
+
+The following formats are supported for the `start_time` parameter.
+
+All examples below correspond to a date time of **11 April 2016** at **1 PM Pacific Time**.
+
+
+**Epoch:** 10 digit timestamp in UTC seconds since 1/1/70, also known as Unix time_t. UTC milliseconds since 1/1/70 (which is the default in Javascript) are also supported, i.e. a 13 digit start time.
+
+    Example (10 digits): **1460404800**
+
+    Example (13 digits): **1460404800000**
+
+**Compressed:** 17 digit timestamp always parsed in UTC.
+
+    Format: **YYYYMMDDHHMMSSsss**
+
+    Example: **20160411130000000**
+
+**ISO 8601:** Timestamp with +/- UTC offset or Z to indicate time is in UTC. Milliseconds are optional.
+
+    Format: **YYYY/MM/DDTHH:MM:SS.sss+hh:mm**
+
+    Example (UTC offset of +3 hours): **2016/04/11T23:00:00.000+03:00**
+
+    Example (UTC offset of -7 hours): **2016/04/11T13:00:00.000-07:00**
+
+    Example (UTC): **2016/04/11T20:00:00.000Z**
+
+    Example (no milliseconds): **2016/04/11T13:00:00-07:00**
+
+**Excel Compatible:** Timestamp parsed in the timezone of the **oauth token**'s associated network. Milliseconds are optional.
+
+    Format: **YYYY/MM/DD HH:MM:SS.sss AM/PM**
+
+    Example: **2016/04/11 13:00:00.000 PM**
+
+    Example (no milliseconds): **2016/04/11 13:00:00 PM**
+
+
+
+Example POST Request Using cURL
+-------------------------------
+
+You can send call results to Invoca servers in the form of an HTTP POST or PUT. cURL is recommended because it is simple and preinstalled on most machines. Below is an example of a cURL request:
+
+.. code-block:: bash
+
+  curl -k -H "Content-Type: application/json" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}],"oauth_token":"<YOUR OAUTH TOKEN>"}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json
+
+Below is the same example as above with the OAuth Token passed in via the request headers:
+
+.. code-block:: bash
+
+  curl -k -H "Content-Type: application/json" -H "Authorization: <YOUR OAUTH TOKEN>" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}]}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json
+
+
+
+Errors
+------
+
+The Call Ingestion API clearly identifies errors when a request cannot be processed.
+
+**Invalid Inputs**
+
+If invalid parameters are passed, an error will be returned with a 403 response code.
+
+For example, if a **call** or parameters within the call are not passed in the request, the following error will be returned.  
+If there are multiple issues with the request, we will do our best to package all of the issues together in one response message.
+
+**Response (403 Forbidden):**
+
+.. code-block:: json
+
+  {
+    "errors": {
+      "class": "RecordInvalid",
+      "invalid_data": "Validation failed: 'call' is required"
+    }
+  }
+
+-----
+
+**Permission Errors**
+
+If you do not have access to the Call Ingestion API, the following error will be returned with a 403 response code.  
+*Please note that the Call Ingestion API is enabled per network.  Please contact the Invoca support team at questions@invoca.com for setup assistance.*
+
+**Response (403 Forbidden):**
+
+.. code-block:: json
+
+    {
+      "errors": {
+        "class": "UnauthorizedOperation",
+        "invalid_data": "You do not have permissions to perform the requested operation."
+      }
+    }
+
+-----
+
+**Authorization Errors**
+
+If you do not have access to the **advertiser_campaign_id_from_network** an error will be returned with a 403 response code.
+For example, if you pass an **advertiser_campaign_id_from_network** that you do not have access to, the following error will be returned.
+
+**Response (403 Forbidden):**
+
+.. code-block:: json
+
+    {
+      "errors": {
+        "class": "UnauthorizedAdvertiser",
+        "invalid_data": "You do not have access to this advertiser"
+      }
+    }
+
+
+Supported Recording Formats
+---------------------------
+
+The default call recording format on the Invoca platform is 16-bit PCM encoded `WAV <https://en.wikipedia.org/wiki/WAV>`_ files with an 8 kHz sample rate. 
+The Call Ingestion API supports `WAV <https://en.wikipedia.org/wiki/WAV>`_  and `MP3 <https://en.wikipedia.org/wiki/MP3>`_ file formats.  However, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
+
+All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1. 
+For all calls submitted via the Call Ingsetion API, we will normalize the channels to match a the Invoca call record channel layout.
+
+The **call_direction** field will determine how the recording is normalized:
+
+    `inbound` The audio processing system will assume that the call recording matches the Invoca default with the caller channel on channel 0 and the agent channel on channel 1.
+
+    `outbound` The audio processing system will assume that the call recording is the opposite of the Invoca dafault.  The audio procesing system will normalize the call recording by swapping the channels.
+
+
+If the Invoca Audio Processing system finds any call recording format problems then a message will be sent via email notifying you of the issue.  Please see the **Call Processing Error Notifications** section for more details.
+
+-----
+
+
+Supported Recording Access Options
+----------------------------------
+
+After a new call is successfully submitted via the API, a message is sent to notify the Invoca Audio Processing system to download the recording and begin processing.
+The audio processing system attempts to download the recording via a standard network request using **wget** or **curl**.  
+
+Call Recording URLs will need to be accessible to the Invoca Audio processing system. There are a couple of ways to configure your recordings to support this requirement:
+
+    `Presigned URL` If the call recording is hosted in `AWS S3 <https://docs.aws.amazon.com/s3/index.html>`_ you can use `presigned URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html>`_.  In this approach, a unique token is created and appended to the URL that grants access for a predefined period of time to the system in which you provide the URL.
+
+    `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys. 
+
+
+If the Invoca Audio Processing system is unable to succesfully download and process the call recording a message will be sent via email notifying you of the issue.  Please see the **Call Processing Error Notifications** section for more details.
+
+
+External Campaign Configuration
+-------------------------------
+
+*Details on this process coming soon*
+
+-----
+
+
+Call Processing Error Notifications
+-----------------------------------
+
+*Details on this process coming soon*
+
+-----
+
+
+Retrying Failed Calls
+---------------------
+
+*Details on this process coming soon*

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -7,7 +7,7 @@ Calls submitted through this API are available to all post-call processing syste
 
 Invoca post-call processing services are applied to calls based on network and campaign settings.  The campaign for the call is determined by the *advertiser_campaign_id_from_network* parameter in the API.
 
-Additionally, Signals and Custom Data related to the call can be sumbitted during the initial call ingestion step.  Please note that Signals and Custom Data can also be applied in the future using the :doc:`../signal_api/index`.
+Additionally, Signals and Custom Data related to the call can be submitted during the initial call ingestion step.  Please note that Signals and Custom Data can also be applied in the future using the :doc:`../signal_api/index`.
 
 Signals can be any boolean value (e.g. sale, quote, etc), and Custom Data can be any alpha-numeric value (e.g. account type, customer quality score, etc).
 
@@ -29,7 +29,7 @@ Remember to check the HTTP status code returned. This helps greatly when debuggi
     - A new call creation request was successfully created.
 
   * - 202 Accepted
-    - The call creation request has already been received and is currently being processed.
+    - The call creation request has already been received.
 
   * - 400 Bad Request
     - Attempted to make a request with an invalid API Version for route. Check the error message for any neccessary corrections
@@ -50,11 +50,11 @@ Passed in “application/json” format.
 
 **Call Parameters**
 
-These are the call datails used when creating the call in the Invoca platform.
+These are the call details used when creating the call in the Invoca platform.
 
     **Required**
 
-    `external_call_unique_id` The unique ID of the call in the system fom the external system.  This field is required to be unique across all calls within a network that are submitted from external sources.
+    `external_call_unique_id` The unique ID of the call from the external system.  This field is required to be unique across all calls within a network that are submitted from external sources.
 
     `start_time` This is the date and time when the call started on the call origination platform.  Please see the **Timestamp Formats** section below for descriptions of supported timestamps.
 
@@ -62,7 +62,7 @@ These are the call datails used when creating the call in the Invoca platform.
 
     `calling_phone_number` ANI in E.164 format +country national_number; example: ‘+18885551212’.
 
-    `advertiser_campaign_id_from_network` ID from network field on advertiser campaign; only calls within this advertiser campaign will be considered (campaign must be in the organization accessed via API).
+    `advertiser_campaign_id_from_network` The ID from network field on the advertiser campaign.  The submitted call will be added to this campaign.  *Please note that this campaign must be of type ExternalOnly*  See :doc:`../network_integration/advertiser_campaigns//index` for more details.
 
     `call_direction` The direction of the call flow.  Accepted values: *inbound* or *outbound*.
 
@@ -79,7 +79,7 @@ Used to create the fields of a signal. The Signal name provided in a request **m
     `name` The name describing the signal event. For reporting a sale happened on a call, “Sale” is recommended.
     Other examples include “Free Trial”, “2yr Subscription”, “Cancellation.”
     This can be used elsewhere in the system and should be a small list of values meaningful to your organization.
-    Names are matched case-insensitively, but we will preserve and use the casing of the first time the signal name is reported.
+    Names are matched case-insensitively.
 
     **Optional**
 
@@ -245,9 +245,8 @@ For example, if you pass an **advertiser_campaign_id_from_network** that you do 
 
 In order to fully utilize the Call Ingestion API, there are some configuration requirements for the campaign that the call is being submitted under.  Here's a list of those requirements:
 
-  * Campaigns must be setup with a campaign type of **External**
-  * Campaigns need to be have the **Signal AI** product feature enabled
-  * Campaigns need to hav at least one Signal configured
+  * Campaigns must be setup with a campaign type of **ExternalOnly**.
+  * Campaigns need to be have either the **Signal AI** product feature or at least one Voice Signal enabled.  This will enable transcription service on the submitted call.
 
 If any of these settings are misconfigured you'll see error message similar to the examples below.  
 *Please contact the Invoca support team at questions@invoca.com for setup assistance.* 
@@ -290,8 +289,7 @@ The **call_direction** field will determine how the recording is normalized:
     `outbound` The audio processing system will assume that the call recording is the opposite of the Invoca dafault.  The audio procesing system will normalize the call recording by swapping the channels.
 
 
-If the Invoca Audio Processing system finds any call recording format problems then a message will be sent via email notifying you of the issue.  
-Processing error emails will be sent to the email address on the user account that is linked to the API token used for the API request.  Please see the **Call Processing Error Notifications** section for more details.
+If the Invoca Audio Processing system finds any call recording format problems then a message will be sent via email notifying your Invoca Customer Success Manager (CSM) who will then reach out to help resolve any issues.  Please see the **Call Processing Error Notifications** section for more details.
 
 
 Supported Recording Access Options
@@ -307,8 +305,7 @@ Call Recording URLs will need to be accessible to the Invoca Audio processing sy
     `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys. 
 
 
-If the Invoca Audio Processing system is unable to succesfully download and process the call recording a message will be sent via email notifying you of the issue.  Please see the **Call Processing Error Notifications** section for more details.
-
+If the Invoca Audio Processing system is unable to succesfully download and process the call recording then a message will be sent via email notifying your Invoca Customer Success Manager (CSM) who will then reach out to help resolve any issues.  Please see the **Call Processing Error Notifications** section for more details.
 
 Call Processing Error Notifications
 -----------------------------------

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -168,14 +168,17 @@ You can send call results to Invoca servers in the form of an HTTP POST or PUT. 
 
 .. code-block:: bash
 
-  curl -k -H "Content-Type: application/json" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}],"oauth_token":"<YOUR OAUTH TOKEN>"}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json
+  curl -POST https://invoca.net/api/api/2022-03-01/calls.json?oauth_token=<oauth_token> \
+    -H 'ContentType: application/json' \
+    -d '{"call":{"external_call_unique_id":"10068","start_time":"2022-03-18 09:31:29","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":86,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"}}'
 
 Below is the same example as above with the OAuth Token passed in via the request headers:
 
 .. code-block:: bash
 
-  curl -k -H "Content-Type: application/json" -H "Authorization: <YOUR OAUTH TOKEN>" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}]}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json
-
+  curl -POST https://invoca.net/api/api/2022-03-01/calls.json \
+    -H 'ContentType: application/json' \
+    -d '{"call":{"external_call_unique_id":"10070","start_time":"2022-03-18 09:31:29","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":86,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"oauth_token":"<oauth_token>"}' 
 
 
 Errors
@@ -241,9 +244,10 @@ For example, if you pass an **advertiser_campaign_id_from_network** that you do 
 **Campaign Configuration Related Errors**
 
 In order to fully utilize the Call Ingestion API, there are some configuration requirements for the campaign that the call is being submitted under.  Here's a list of those requirements:
+
   * Campaigns must be setup with a campaign type of **External**
-  * Campaigns need to be configured with transciption enabled
-  * Campaigns need to have Signal AI enabled at at least one Signal configured
+  * Campaigns need to be have the **Signal AI** product feature enabled
+  * Campaigns need to hav at least one Signal configured
 
 If any of these settings are misconfigured you'll see error message similar to the examples below.  
 *Please contact the Invoca support team at questions@invoca.com for setup assistance.* 
@@ -277,7 +281,7 @@ The default call recording format on the Invoca platform is 16-bit PCM encoded `
 The Call Ingestion API supports `WAV <https://en.wikipedia.org/wiki/WAV>`_  and `MP3 <https://en.wikipedia.org/wiki/MP3>`_ file formats.  However, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
 
 All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1. 
-For all calls submitted via the Call Ingsetion API, we will normalize the channels to match a the Invoca call record channel layout.
+For all calls submitted via the Call Ingestion API, we will normalize the channels to match the Invoca call record channel layout.
 
 The **call_direction** field will determine how the recording is normalized:
 
@@ -286,9 +290,8 @@ The **call_direction** field will determine how the recording is normalized:
     `outbound` The audio processing system will assume that the call recording is the opposite of the Invoca dafault.  The audio procesing system will normalize the call recording by swapping the channels.
 
 
-If the Invoca Audio Processing system finds any call recording format problems then a message will be sent via email notifying you of the issue.  Please see the **Call Processing Error Notifications** section for more details.
-
------
+If the Invoca Audio Processing system finds any call recording format problems then a message will be sent via email notifying you of the issue.  
+Processing error emails will be sent to the email address on the user account that is linked to the API token used for the API request.  Please see the **Call Processing Error Notifications** section for more details.
 
 
 Supported Recording Access Options

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -109,11 +109,11 @@ The Custom Data Fields provided in a request **must** already exist in your `Cus
 
 Endpoint:
 
-``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json``
+``https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json``
 
 .. api_endpoint::
   :verb: POST
-  :path: /transactions/create
+  :path: /calls
   :description: Create a new call in the Invoca platform.
   :page: create_call
 
@@ -168,13 +168,13 @@ You can send call results to Invoca servers in the form of an HTTP POST or PUT. 
 
 .. code-block:: bash
 
-  curl -k -H "Content-Type: application/json" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}],"oauth_token":"<YOUR OAUTH TOKEN>"}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json
+  curl -k -H "Content-Type: application/json" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}],"oauth_token":"<YOUR OAUTH TOKEN>"}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json
 
 Below is the same example as above with the OAuth Token passed in via the request headers:
 
 .. code-block:: bash
 
-  curl -k -H "Content-Type: application/json" -H "Authorization: <YOUR OAUTH TOKEN>" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}]}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/transactions/create.json
+  curl -k -H "Content-Type: application/json" -H "Authorization: <YOUR OAUTH TOKEN>" -X POST -d '{"call":{"external_call_unique_id":"123ABC","start_time":"2016-08-08 11:03:31 -0700","destination_phone_number":9093900003,"calling_phone_number":8779257383,"advertiser_campaign_id_from_network":85,"call_direction":"inbound","recording_url":"<CALL RECORDING URL>"},"signals":[{"name":"sale","value":1},{"name":"quote","value":1}],"custom_data":[{"name":"channel","value":"Paid Search"},{"name":"line_of_business","value":"Social"}]}'  https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json
 
 
 

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -236,7 +236,38 @@ For example, if you pass an **advertiser_campaign_id_from_network** that you do 
         "invalid_data": "You do not have access to this advertiser"
       }
     }
+-----
 
+**Campaign Configuration Related Errors**
+
+In order to fully utilize the Call Ingestion API, there are some configuration requirements for the campaign that the call is being submitted under.  Here's a list of those requirements:
+  * Campaigns must be setup with a campaign type of **External**
+  * Campaigns need to be configured with transciption enabled
+  * Campaigns need to have Signal AI enabled at at least one Signal configured
+
+If any of these settings are not configured you'll see error message similar to the example below.  
+*Please contact the Invoca support team at questions@invoca.com for setup assistance.* 
+
+**Response (403 Forbidden):**
+
+.. code-block:: json
+
+    {
+      "errors": {
+        "class": "call.advertiser_campaign_id_from_network",
+        "invalid_data": "campaign must be for external calls only"
+      }
+    }
+
+
+.. code-block:: json
+
+    {
+      "errors": {
+        "class": "call.advertiser_campaign_id_from_network",
+        "invalid_data": "campaign must have transcription enabled"
+      }
+    }
 
 Supported Recording Formats
 ---------------------------
@@ -273,14 +304,6 @@ Call Recording URLs will need to be accessible to the Invoca Audio processing sy
 
 
 If the Invoca Audio Processing system is unable to succesfully download and process the call recording a message will be sent via email notifying you of the issue.  Please see the **Call Processing Error Notifications** section for more details.
-
-
-External Campaign Configuration
--------------------------------
-
-*Details on this process coming soon*
-
------
 
 
 Call Processing Error Notifications

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -245,7 +245,7 @@ In order to fully utilize the Call Ingestion API, there are some configuration r
   * Campaigns need to be configured with transciption enabled
   * Campaigns need to have Signal AI enabled at at least one Signal configured
 
-If any of these settings are not configured you'll see error message similar to the example below.  
+If any of these settings are misconfigured you'll see error message similar to the examples below.  
 *Please contact the Invoca support team at questions@invoca.com for setup assistance.* 
 
 **Response (403 Forbidden):**
@@ -259,6 +259,7 @@ If any of these settings are not configured you'll see error message similar to 
       }
     }
 
+**Response (403 Forbidden):**
 
 .. code-block:: json
 

--- a/source/api_documentation/index.rst
+++ b/source/api_documentation/index.rst
@@ -23,6 +23,8 @@ used to report signals that occur on a specific call (transaction).
 :doc:`call_api/index` -
 used to pull transcript information for a specific call (transcript).
 
+:doc:`call_ingestion_api/index` -
+used to ingest calls from external sources for conversation intelligence processing and inclusion in your reports and dashboards.
 
 The Transactions API and Network Integration API are accessible using the API credentials generated on the platform. See :doc:`manage_api_credentials` for more information.
 
@@ -49,3 +51,4 @@ The RingPool wizard includes a section showing the correct API URL for your orga
    signal_api/index
    call_api/index
    conversion_reporting
+   call_ingestion_api/index

--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -36,7 +36,11 @@ You are not allowed to delete campaigns.
 
   * - campaign_type
     - string
-    - 2 Campaign Types Supported: “AffiliateEnabled” ‐ Advertiser Campaign that allows Affiliates to promote it. Includes Payin and Payouts for qualified Calls. “DirectOnly” ‐ Advertiser Campaign used for internal marketing. No ability to promote via Affiliates or setup Payin and Payouts for Calls.
+    - 3 Campaign Types Supported:
+
+      * **AffiliateEnabled:** Advertiser Campaign that allows Affiliates to promote it. Includes Payin and Payouts for qualified Calls. 
+      * **DirectOnly:** Advertiser Campaign used for internal marketing. No ability to promote via Affiliates or setup Payin and Payouts for Calls.
+      * **ExternalOnly:** Advertiser Campaign used for external calls uploaded via the Call Ingestion API. See :doc:`../../call_ingestion_api/index` for more details.
 
   * - description
     - string

--- a/source/doc_versions.py
+++ b/source/doc_versions.py
@@ -1,6 +1,6 @@
 # The API version strings to display in the documentation
 # COMMON_VERSION is the latest version of any one API, and is considered the overall API version
-COMMON_VERSION = '2020-10-01'
+COMMON_VERSION = '2022-03-01'
 
 VERSIONS = {
     '@@NETWORK_API_VERSION':           '2019-05-01',
@@ -10,5 +10,6 @@ VERSIONS = {
     '@@RINGPOOL_API_VERSION':          '2015-12-09',
     '@@PNAPI_VERSION':                 '2013-07-01',
     '@@SIGNAL_API_VERSION':            '2018-02-01',
-    '@@CALL_API_VERSION':              '2020-10-01'
+    '@@CALL_API_VERSION':              '2020-10-01',
+    '@@CALL_INGESTION_API_VERSION':    '2022-03-01'
 }


### PR DESCRIPTION
[Adding External Call API Documentation](https://invoca.atlassian.net/browse/STORY-11055) 
This PR adds developer documentation for the new External Call API.  The External Call API is used by customers to submit calls that didn't route across the our platform to Invoca so that we can still transcribe, process signals, and import the call in the Data Warehouse. 

Here's a link the private version of the documentation: 
[Doc Link](https://developers.invoca.net/en/2022-03-01/api_documentation/call_ingestion_api/index.html)

_Please note:  This is a new version/branch, so this PR was opened up with a base version of the previous documentation version: 2020-10-01.  Once approved, this PR will not be merged since the new version already exists.  Instead, this PR will be closed with a note and the new documentation will be made publicly available for our customers._

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
