### PR TITLE
STORY-11201: Add language_code for call ingestion API doc

### DIFF
--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -70,7 +70,7 @@ These are the call details used when creating the call in the Invoca platform.
 
     **Optional**
 
-    `language_code` The IETF language tag for the call transcription. This parameter can be processed only if multiple language processing is enabled for the network. The default is given from the network attribute ("default_language_code") if it is set, otherwise "en-US". The following language codes are supported:
+    `language_code` The IETF language tag for the call transcription. This parameter can be processed only if multiple language processing is enabled for the network or it matches the default language code of the network. The default is given from the network attribute ("default_language_code") if it is set, otherwise "en-US". The following language codes are supported:
 
     .. list-table::
       :widths: 8 40

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -70,7 +70,27 @@ These are the call details used when creating the call in the Invoca platform.
 
     **Optional**
 
-    `language_code` The IETF language code for the call transcription. The supported codes are: `en-US`, `en-GB`, `es-ES`, `fr-FR`. This parameter can be processed only if `multiple_language_processing` for the network is enabled. The default is the `default_language_code` for the network if it is set, otherwise `en-US`.
+    `language_code` The IETF language tag for the call transcription. This parameter can be processed only if multiple language processing is enabled for the network. The default is given from the network attribute ("default_language_code") if it is set, otherwise "en-US". The following language codes are supported:
+
+    .. list-table::
+      :widths: 8 40
+      :header-rows: 1
+      :class: parameters
+
+      * - Language Code
+        - Description
+
+      * - en-US
+        - English (United States)
+
+      * - en-GB
+        - English (United Kingdom)
+
+      * - es-ES
+        - Spanish (Spain)
+
+      * - fr-FR
+        - French (France)
 
 -----
 

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -67,7 +67,11 @@ These are the call details used when creating the call in the Invoca platform.
     `call_direction` The direction of the call flow.  Accepted values: *inbound* or *outbound*.
 
     `recording_url` The URL to the call recording. Please see the **Supported Recording Formats** and **Supported Recording Access Options** sections for more details.
-    
+
+    **Optional**
+
+    `language_code` The IETF language code for the call transcription. The supported codes are: `en-US`, `en-GB`, `es-ES`, `fr-FR`. This parameter can be processed only if `multiple_language_processing` for the network is enabled. The default is the `default_language_code` for the network if it is set, otherwise `en-US`.
+
 -----
 
 **Signal Parameters**


### PR DESCRIPTION
Adding language_code parameter doc for call ingestion API. Part of [this ticket](https://invoca.atlassian.net/browse/STORY-11201)

<!-- Each Pull Request should focus on a single API family -->

See the updated `Request Parameters` section in [this private doc version](https://developers.invoca.net/en/story-11201-multi-language-feature-allow-call-language-code-to-be-passed-in/api_documentation/call_ingestion_api/index.html#request-parameters).
## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
