### PR TITLE
STORY-11138: Add documentation for RingGroup and more

### DIFF
--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -287,7 +287,7 @@ Node Parameters and Usage
   * - Failover
     - \*destination_phone_number
 
-    - Forwards the call to a fallback destination number if the original destination configured on the parent "Connect" node returns a busy signal OR if the configured connect_timeout value on the parent "Connect" node is exceeded. This node type can only be configured as a child of "Connect" nodes.
+    - Forwards the call to a fallback destination number if the original destination configured on the parent node returns a busy signal OR if the configured connect_timeout value on the parent node is exceeded. Can only be configured as the child of another node, and not as a standalone node.
 
   * - EndCall
     - prompt
@@ -415,7 +415,7 @@ Node Details
     - May not have any children unless ringing_rollover is enabled for the network. The prompt will be read before connecting to the provided phone number. If ringing_rollover is enabled for the network, a connect_timeout value can be configured along with a "Failover" child node.
 
   * - Failover
-    - May not have any children. The provided phone number will be dialed if the destination configured on the parent "Connect" node returns a busy signal when dialed OR if the connect_timeout value configured on the parent "Connect" node is exceeded. This node type can only be configured as a child of "Connect" nodes.
+    - May not have any children. The provided phone number will be dialed if the destination configured on the parent node returns a busy signal when dialed OR if the connect_timeout value configured on the parent node is exceeded. Can only be configured as the child of another node, and not as a standalone node.
 
   * - EndCall
     - May not have any children. The prompt will be read before ending the call.
@@ -445,7 +445,7 @@ Node Details
     - May have exactly 2 child nodes. If a keypress of 1 is made, the first child node is executed. If a kepyress of 2 is made, the second child node is executed. If speech recognition is enabled, the caller can also say "yes" for 1 and "no" for 2. At the end of the child list, this node type can also optionally have failover child nodes, designated by a node with a keypress_failover_type parameter (see example below).
 
   * - RingGroup
-    - May not have any children. Forwards the call to a group of numbers that will be dialed in the order determined by the distribution method. If a destination plays a busy signal OR the ring_group_connect_timeout value is exceeded before the call is answered (or accepted), the next destination will be dialed. This node type also allows for simultaneous calling when it is enabled.
+    - Forwards the call to a group of numbers that will be dialed in the order determined by the distribution method. If a destination plays a busy signal OR the ring_group_connect_timeout value is exceeded before the call is answered (or accepted), the next destination will be dialed. This node type also allows for simultaneous calling when it is enabled.
 
 Parameter Details
 


### PR DESCRIPTION
[STORY-11138](https://invoca.atlassian.net/browse/STORY-11138)

Adding documentation for RingGroup node and its params, as well as updating DynamicRoute for when it behaves like RingGroup, and accounting for Failover node as a child of Connect

## Screenshot Demo
<img width="424" alt="Node Params and Usage" src="https://user-images.githubusercontent.com/26881159/181120868-5731fa61-2931-46ca-9416-98f3b7c6cfa2.png">
<img width="843" alt="Node Details" src="https://user-images.githubusercontent.com/26881159/181120843-a181e829-9b26-4a7a-8ad1-db65db1e663a.png">
<img width="632" alt="Parameter Details" src="https://user-images.githubusercontent.com/26881159/181120832-d9a67ca0-33f7-46e0-a451-98ae771870a5.png">


<!-- Each Pull Request should focus on a single API family -->

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
