### PR TITLE
STORY-12459: Updating rollup banner with alert-warning CSS class and updating verbiage for existing users when upgrading to a new version

### DIFF
--- a/source/api_documentation/transactions_api/_rollup_message.rst
+++ b/source/api_documentation/transactions_api/_rollup_message.rst
@@ -3,9 +3,9 @@
   <h2>
     Signal Transactions Rollup
   </h2>
-  <div class="alert alert-danger">
+  <div class="alert alert-warning">
     <p>
-      API versions <b>2020-10-01</b> and later only return rollup rows of transaction types "Call", "Sale", and "Post Call Event".
+      If you're upgrading from an API versions older than <b>2020-10-01</b> we suggest testing to familiarize yourself with the updated Signal data structure.
     </p>
     <p>
       For more information, view the support documentation for <a href="https://community.invoca.com/t5/developer-features/how-to-access-invoca-call-data-programmatically-via-api/ta-p/602" target="_blank">best practices in accessing Invoca Call Data via the Transactions API</a>.

--- a/source/api_documentation/transactions_api/_rollup_message.rst
+++ b/source/api_documentation/transactions_api/_rollup_message.rst
@@ -5,7 +5,7 @@
   </h2>
   <div class="alert alert-warning">
     <p>
-      If you're upgrading from an API versions older than <b>2020-10-01</b> we suggest testing to familiarize yourself with the updated Signal data structure.
+      If you're upgrading from API versions older than <b>2020-10-01</b> we suggest testing to familiarize yourself with the updated Signal data structure.
     </p>
     <p>
       For more information, view the support documentation for <a href="https://community.invoca.com/t5/developer-features/how-to-access-invoca-call-data-programmatically-via-api/ta-p/602" target="_blank">best practices in accessing Invoca Call Data via the Transactions API</a>.


### PR DESCRIPTION
@shebesabrina and I paired on this, I'm opening the pull request because we're not sure why she's not able to (we think it may be a github group thing ¯\\_(ツ)_/¯)

[STORY-12459](https://invoca.atlassian.net/browse/STORY-12459)
![Screen Shot 2022-09-16 at 5 22 37 PM](https://user-images.githubusercontent.com/9993068/190829976-86027592-8e54-4159-9883-a7571e8d44a0.png)

## Checklist
- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
   - In this case, signal rollup is a project/feature that not many people have experience with, so we'll be relying on those few people that do.
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
   - Not applicable
