### PR TITLE
Add Secure Recording documentation to Call Ingestion API

### DIFF
--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -92,7 +92,7 @@ These are the call details used when creating the call in the Invoca platform.
       * - fr-FR
         - French (France)
 
-    `recording_auth_config_id` The ID from the Auth Configuration object. This parameter can be processed only if you have setup an Auth Configuration object. Passing this parameter enables you to use the supported secure recording access options.
+    `recording_auth_config_id` The ID from the Auth Configuration setup step. Please see the **Supported Recording Access Options** section for more details.
 
 
 -----
@@ -354,7 +354,7 @@ Call Recording URLs will need to be accessible to the Invoca Audio processing sy
 
     `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys.
 
-    `Secure Recording` In this approach, some additional setup is required. If accessing your call recordings requires making a request with a secure token, you will need to setup an Auth Configuration object with Invoca prod support. Prod support will provide you with a 'recording_auth_config_id', which when passed as a parameter in your API request, will enable the Invoca Audio Processing system to download the secured recording. Currently, the following authentication methods are supported:
+    `Secure Recording URL` If accessing your call recordings requires an access token, you will need to setup an Auth Configuration with Invoca prod support, who will provide you with the corresponding Auth Configuration ID. When passed as a parameter in your API request, the *recording_auth_config_id* will enable the Invoca Audio Processing system to access the recording. Currently, the following authentication methods are supported:
 
     .. list-table::
       :widths: 8 40

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -92,6 +92,9 @@ These are the call details used when creating the call in the Invoca platform.
       * - fr-FR
         - French (France)
 
+    `recording_auth_config_id` The ID from the Auth Configuration object. This parameter can be processed only if you have setup an Auth Configuration object. Passing this parameter enables you to use the supported secure recording access options.
+
+
 -----
 
 **Signal Parameters**
@@ -349,7 +352,26 @@ Call Recording URLs will need to be accessible to the Invoca Audio processing sy
 
     `Presigned URL` If the call recording is hosted in `AWS S3 <https://docs.aws.amazon.com/s3/index.html>`_ you can use `presigned URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html>`_.  In this approach, a unique token is created and appended to the URL that grants access for a predefined period of time to the system in which you provide the URL.
 
-    `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys. 
+    `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys.
+
+    `Secure Recording` In this approach, some additional setup is required. If accessing your call recordings requires making a request with a secure token, you will need to setup an Auth Configuration object with Invoca prod support. Prod support will provide you with a 'recording_auth_config_id', which when passed as a parameter in your API request, will enable the Invoca Audio Processing system to download the secured recording. Currently, the following authentication methods are supported:
+
+    .. list-table::
+      :widths: 8 40
+      :header-rows: 1
+      :class: parameters
+
+      * - Authentication Method
+        - Description
+
+      * - HTTP Authentication Header
+        - Sends a header with the format `Authorization: Bearer <Token>`
+
+      * - Query String Parameter
+        - Appends a new query string param to the recording_url parameter with the format `?<Query String>=<Token>`.
+
+      * - Custom Header
+        - Sends a header with the format `<Custom Header>: <Token>`
 
 
 If the Invoca Audio Processing system is unable to succesfully download and process the call recording then a message will be sent via email notifying your Invoca Customer Success Manager (CSM) who will then reach out to help resolve any issues.  Please see the **Call Processing Error Notifications** section for more details.

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -354,7 +354,7 @@ Call Recording URLs will need to be accessible to the Invoca Audio processing sy
 
     `Public URL` In this approach, the call recording would be able to be downloaded without requirement of access credentials or API keys.
 
-    `Secure Recording URL` If accessing your call recordings requires an access token, you will need to setup an Auth Configuration with Invoca prod support, who will provide you with the corresponding Auth Configuration ID. When passed as a parameter in your API request, the *recording_auth_config_id* will enable the Invoca Audio Processing system to access the recording. Currently, the following authentication methods are supported:
+    `Secure Recording URL` If accessing your call recordings requires an access token, you will need to setup an Auth Configuration with Invoca support. After setup, Invoca will provide you with the corresponding Auth Configuration ID. When passed as a parameter in your API request, the *recording_auth_config_id* will enable the Invoca Audio Processing system to access the recording. Currently, the following authentication methods are supported:
 
     .. list-table::
       :widths: 8 40


### PR DESCRIPTION
[Jira Link](https://invoca.atlassian.net/browse/STORY-12513)

Added documentation for secure recording. Screenshots of the changes  to the dev docs can be found in a comment on the JIRA. 

This PR focuses only on the Call Ingestion API Docs.

This [confluence doc](https://invoca.atlassian.net/wiki/spaces/DEV/pages/59565768705/Secure+Recording+Access+-+Auth+Configuration+Setup) detailing how to set up an AuthConfig object was also made as part of this work.

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
