### PR TITLE
STORY-12601 - Add MP4 as a supported recording type to Call Ingestion API

### DIFF
--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -323,10 +323,18 @@ If any of these settings are misconfigured you'll see error message similar to t
 Supported Recording Formats
 ---------------------------
 
-The default call recording format on the Invoca platform is 16-bit PCM encoded `WAV <https://en.wikipedia.org/wiki/WAV>`_ files with an 8 kHz sample rate. 
-The Call Ingestion API supports `WAV <https://en.wikipedia.org/wiki/WAV>`_ , `MP3 <https://en.wikipedia.org/wiki/MP3>`_ and `MP4 <https://en.wikipedia.org/wiki/MP4_file_format>`_ file formats.  However, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
+The Call Ingestion API supports the following file formats:
+  * `WAV <https://en.wikipedia.org/wiki/WAV>`_
 
-All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1. 
+  * `MP3 <https://en.wikipedia.org/wiki/MP3>`_
+
+  * `MP4 <https://en.wikipedia.org/wiki/MP4_file_format>`_
+
+    * Note: MP4s should be audio-only
+
+The default call recording format on the Invoca platform is 16-bit PCM encoded `WAV <https://en.wikipedia.org/wiki/WAV>`_ files with an 8 kHz sample rate. Please note that the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
+
+All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1.
 For all calls submitted via the Call Ingestion API, we will normalize the channels to match the Invoca call record channel layout.
 
 The **call_direction** field will determine how the recording is normalized:

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -324,7 +324,7 @@ Supported Recording Formats
 ---------------------------
 
 The default call recording format on the Invoca platform is 16-bit PCM encoded `WAV <https://en.wikipedia.org/wiki/WAV>`_ files with an 8 kHz sample rate. 
-The Call Ingestion API supports `WAV <https://en.wikipedia.org/wiki/WAV>`_  and `MP3 <https://en.wikipedia.org/wiki/MP3>`_ file formats.  However, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
+The Call Ingestion API supports `WAV <https://en.wikipedia.org/wiki/WAV>`_ , `MP3 <https://en.wikipedia.org/wiki/MP3>`_ and `MP4 <https://en.wikipedia.org/wiki/MP4_file_format>`_ file formats.  However, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
 
 All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1. 
 For all calls submitted via the Call Ingestion API, we will normalize the channels to match the Invoca call record channel layout.

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -332,7 +332,7 @@ The Call Ingestion API supports the following file formats:
 
     * Note: MP4s should be audio-only
 
-The default call recording format on the Invoca platform is 16-bit PCM encoded `WAV <https://en.wikipedia.org/wiki/WAV>`_ files with an 8 kHz sample rate. Please note that the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format.
+Please note that after ingestion, the Invoca Audio Processing system will upsample or downsample accordingly into our default call recording format, which is: `MP3 <https://en.wikipedia.org/wiki/MP3>`_ with an 8 kHz sample rate.
 
 All call recordings are required to be in dual-channel or stereo format.  The call recording of an inbound call on the Invoca platform has the caller channel on channel 0 and the agent audio on channel 1.
 For all calls submitted via the Call Ingestion API, we will normalize the channels to match the Invoca call record channel layout.


### PR DESCRIPTION
[Jira ticket](https://invoca.atlassian.net/browse/STORY-12601)

Updates the [Call Ingestion API Documentation](https://developers.invoca.net/en/2022-08-01/api_documentation/call_ingestion_api/index.html) to add MP4 as a supported recording type.
Also reformats the list for readability, and fixes a comment about the default recording type being MP3 once processed by our platform.

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
  - Latest version
