### PR TITLE
STORY-14616 added call_record_id to Calls In Progress response payloa…

### DIFF
--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
@@ -28,6 +28,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
@@ -29,6 +29,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
@@ -29,6 +29,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
@@ -25,6 +25,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {
@@ -42,6 +43,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:05:42-07:00",
+          "call_record_id": "Z6E5-C7397356576G",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
@@ -44,6 +44,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
@@ -44,6 +44,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {

--- a/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
@@ -40,6 +40,7 @@
           "destination_phone_number": "+18555595599",
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
           "phone_type": "Mobile",
           "custom_data": {
                 "utm_source": {


### PR DESCRIPTION
Added call_record_id field to CIPAPI response payloads

[STORY-14616](https://invoca.atlassian.net/browse/STORY-14616)

<!-- Each Pull Request should focus on a single API family -->

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)


[STORY-14616]: https://invoca.atlassian.net/browse/STORY-14616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ