### PR TITLE
Update Invoca API token authentication help

### DIFF
--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -132,7 +132,7 @@ The Custom Data Fields provided in a request **must** already exist in your `Cus
 
     **Required**
 
-    `oauth_token` API token for authentication. Can be specified in the header or body of the request (See :doc:`manage_api_credentials`)
+    `oauth_token` API token for authentication. Can be specified in the header or body of the request (See :doc:`../manage_api_credentials`)
 
 Endpoint:
 

--- a/source/api_documentation/call_ingestion_api/index.rst
+++ b/source/api_documentation/call_ingestion_api/index.rst
@@ -132,7 +132,7 @@ The Custom Data Fields provided in a request **must** already exist in your `Cus
 
     **Required**
 
-    `oauth_token` API token for authentication. Can be specified in the body or header of the request.
+    `oauth_token` API token for authentication. Can be specified in the header or body of the request (See :doc:`manage_api_credentials`)
 
 Endpoint:
 
@@ -195,8 +195,9 @@ You can send call results to Invoca servers in the form of an HTTP POST or PUT. 
 
 .. code-block:: bash
 
-  curl --location --request POST 'https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json?oauth_token=<oauth_token>' \
+  curl --location --request POST 'https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json' \
   --header 'Content-Type: application/json' \
+  --header 'Authorization: <token>' \
   --data-raw '
   {
     "call": {
@@ -216,6 +217,7 @@ Below is the same example as above with the OAuth Token passed in via the reques
 
   curl --location --request POST 'https://invoca.net/api/@@CALL_INGESTION_API_VERSION/calls.json' \
   --header 'Content-Type: application/json' \
+  --header 'Authorization: <token>' \
   --data-raw '
   {
     "call": {
@@ -226,8 +228,7 @@ Below is the same example as above with the OAuth Token passed in via the reques
       "advertiser_campaign_id_from_network": 86,
       "call_direction": "inbound",
       "recording_url": "<CALL RECORDING URL>"
-    },
-    "oauth_token": "<oauth_token>"
+    }
   }'
   
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
@@ -4,11 +4,11 @@
 
   Get calls in progress for the External Unique ID `mycalls00001`.
   Note: External Unique ID must be set by using the Update function of this API before you can use it to look up a call.
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&external_unique_id=mycalls00001``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>&external_unique_id=mycalls00001``
 
   Parameters: `external_unique_id` is required for this request
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
@@ -4,7 +4,7 @@
 
   Get calls in progress for the External Unique ID `mycalls00001`.
   Note: External Unique ID must be set by using the Update function of this API before you can use it to look up a call.
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_external_unique_id.rst
@@ -4,7 +4,7 @@
 
   Get calls in progress for the External Unique ID `mycalls00001`.
   Note: External Unique ID must be set by using the Update function of this API before you can use it to look up a call.
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get calls in progress for the calling phone number `530-999-9999` and destination phone number `855-559-5599`.
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   This example is for an organization with Enhanced Caller Profiles enabled, so the demographics data is included in the response.
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get calls in progress for the calling phone number `530-999-9999` and destination phone number `855-559-5599`.
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   This example is for an organization with Enhanced Caller Profiles enabled, so the demographics data is included in the response.
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_phone_number.rst
@@ -3,13 +3,13 @@
   .. rubric:: Example
 
   Get calls in progress for the calling phone number `530-999-9999` and destination phone number `855-559-5599`.
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   This example is for an organization with Enhanced Caller Profiles enabled, so the demographics data is included in the response.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&calling_phone_number=5309999999&destination_phone_number=8555595599``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>&calling_phone_number=5309999999&destination_phone_number=8555595599``
 
   Parameters: `calling_phone_number` and `destination_phone_number` are required for this request
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
@@ -3,13 +3,13 @@
   .. rubric:: Example
 
   Get calls in progress for transaction id `ABCD1234-ABCD1234`.
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   `current_calls` will be ordered by `bridge_start_time`, most recent first.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
 
   Parameters: `transaction_id` is required for this request
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get calls in progress for transaction id `ABCD1234-ABCD1234`.
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   `current_calls` will be ordered by `bridge_start_time`, most recent first.
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get calls in progress for transaction id `ABCD1234-ABCD1234`.
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   `current_calls` will be ordered by `bridge_start_time`, most recent first.
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get all available calls in progress for the specified organization.
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
@@ -3,7 +3,7 @@
   .. rubric:: Example
 
   Get all available calls in progress for the specified organization.
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_in_progress.rst
@@ -3,11 +3,11 @@
   .. rubric:: Example
 
   Get all available calls in progress for the specified organization.
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>``
 
   Response Code: 200
 

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
@@ -7,11 +7,11 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
 
   Parameters:
   `transaction_id` is required for this request

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
@@ -7,7 +7,7 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data.rst
@@ -7,7 +7,7 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
@@ -7,11 +7,11 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&external_unique_id=mycalls00001``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?id=<organization_id>&organization_type=<organization_type>&external_unique_id=mycalls00001``
 
   Parameters:
   `external_unique_id` is required for this request

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
@@ -7,7 +7,7 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_custom_data_ext.rst
@@ -7,7 +7,7 @@
   **Note:** You will not see the new custom data field value in the response or in subsequent queries using this API.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
@@ -5,7 +5,7 @@
   Update the call currently in progress whose transaction ID is `ABCD1234-ABCD1234`. Set the external unique ID to `mycalls00001`.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
+  Be sure to use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
@@ -5,7 +5,7 @@
   Update the call currently in progress whose transaction ID is `ABCD1234-ABCD1234`. Set the external unique ID to `mycalls00001`.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
+  Be sure to include your API token (see :doc:`../manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 

--- a/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_update_external_unique_id.rst
@@ -5,11 +5,11 @@
   Update the call currently in progress whose transaction ID is `ABCD1234-ABCD1234`. Set the external unique ID to `mycalls00001`.
 
   This example uses ``PUT`` requests, but we will also accept ``POST`` requests with the same request format (JSON).
-  Be sure to use your own oauth_token, organization_type and id.
+  Be sure to include your API token (see :doc:`manage_api_credentials`) and use your own organization_type and id.
 
   Endpoint:
 
-  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?oauth_token=<oauth_token>&id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress.json?id=<organization_id>&organization_type=<organization_type>&transaction_id=ABCD1234-ABCD1234``
 
   Parameters:
   `transaction_id` is required for this request

--- a/source/api_documentation/calls_in_progress_api/index.rst
+++ b/source/api_documentation/calls_in_progress_api/index.rst
@@ -13,6 +13,8 @@ The Calls In Progress API is used for interacting with pre-call insights for liv
 information and set custom data values during a call. Calls become available via the api as soon as they are transferred to
 the campaign's destination. Once the call is complete, it is no longer available via the API.
 
+For authentication, use an API token. See :doc:`../manage_api_credentials` for details.
+
 Find Calls in Progress
 ------------------------
 Perform a `GET` request to query calls currently in progress for the specified organization. Sending only the required

--- a/source/api_documentation/manage_api_credentials.rst
+++ b/source/api_documentation/manage_api_credentials.rst
@@ -11,7 +11,7 @@ Create an API Token
 
 To create an API token:
 
-1. From the Navigation Bar, hover on Integrations and select "Invoca APIs"
+1. From the Main Navigation, go to Integrations and select "Invoca APIs"
 
    .. image:: ../_static/manage_api_credentials.png
       :scale: 50%
@@ -22,21 +22,24 @@ To create an API token:
 Note: It is recommended to provide a description that identifies the API type and use.
 
 
-Delete an API Token
--------------------
+Using API Token to Access Invoca APIs
+---------------------------------------
 
-To delete or remove an API token from your platform:
+You can send the access token in a variety of ways:
 
-1. From the Navigation Bar, hover on Integrations and select "Invoca APIs"
+* **Recommended**: As an Authorization header of your request, of format `"Authorization: <token>"`
+* As a URL string parameter (for GET requests), of format `?oauth_token=<token>`
+* As a key/value pair in the JSON body (for POST requests of type JSON), of format `{ "oauth_token": "<token>", ... }`
 
-   .. image:: ../_static/manage_api_credentials.png
-      :scale: 50%
+Example using Curl to make an API call with token-based authentication:
 
-2. On the "Invoca API Credentials" page, click the delete icon associated to the API token to delete.
+.. code-block:: bash
+
+  curl -X POST -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: YbcFHZ38FNfptfZMB0RZ6dk9dOJCaCfU" 'https://\<vanity\>.invoca.net/api/@@NETWORK_API_VERSION/advertisers/1111.json'
 
 
 API Guidelines
---------------
+**************
 
 - Users should generate their own API tokens. Tokens should be treated like passwords and not be emailed or transmitted over other insecure mediums, nor should they be stored in a customer's source code repository.
 

--- a/source/api_documentation/manage_api_credentials.rst
+++ b/source/api_documentation/manage_api_credentials.rst
@@ -3,8 +3,6 @@ Manage API Credentials
 
 Invoca's self-serve API token access is OAuth-compliant. Accessing APIs using the API token enables customers to access and in some cases modify information through a third-party app or APIs without the risk of compromising security. It also ensures that secure, sensitive customer-related information is not exposed to the third-party app.
 
-Currently, users can generate API credentials for the :doc:`Transactions API <transactions_api/index>` and :doc:`Network Integration API <network_integration/index>` (the Network Integration API is available to Network users only).
-
 
 Create an API Token
 -------------------
@@ -22,7 +20,7 @@ To create an API token:
 Note: It is recommended to provide a description that identifies the API type and use.
 
 
-Using API Token to Access Invoca APIs
+Using API Tokens to Access Invoca APIs
 ---------------------------------------
 
 You can send the access token in a variety of ways:

--- a/source/api_documentation/transactions_api/advertiser_user.rst
+++ b/source/api_documentation/transactions_api/advertiser_user.rst
@@ -64,48 +64,42 @@ Example 1: Get the next 20 transactions that occurred after transaction id C624D
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 2: Get 50 rows from a specific time period with only the transaction_id and all Marketing Data columns:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=50&include_columns=transaction_id,$invoca_custom_columns&exclude_columns=$invoca_default_columns&from=2015-03-26&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=50&include_columns=transaction_id,$invoca_custom_columns&exclude_columns=$invoca_default_columns&from=2015-03-26&to=2015-03-27'
 
 
 Example 3: Get 50 rows that exclude a few columns such as Caller ID and Call Recordings:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=50&exclude_columns=calling_phone_number,recording&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?limit=50&exclude_columns=calling_phone_number,recording&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 4: Get All Transactions from a specific time period that are of transaction_type Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27'
 
 
 Example 5: Get All Transactions from a specific time period that are of transaction_type Post Call Event:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27'
 
 
 Example 6: Get All Transactions from a specific time period that are of transaction_type Call and Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
-
-Example 7: Get All Transactions from a specific time period with oauth token in the request header:
-
-.. code-block:: bash
-
-  curl -k -H 'Authorization: YbcFH' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&transaction_type[]=PostCallEvent&from=2015-03-24&to=2015-03-27'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/advertisers/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27'
 
 
 Endpoint:

--- a/source/api_documentation/transactions_api/affiliate_user.rst
+++ b/source/api_documentation/transactions_api/affiliate_user.rst
@@ -53,48 +53,42 @@ Example 1: Get the next 20 transactions that occurred after transaction id C624D
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 2: Get 50 rows from a specific time period with only the transaction_id and duration columns:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=50&include_columns=transaction_id,duration&from=2015-03-26&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=50&include_columns=transaction_id,duration&from=2015-03-26&to=2015-03-27'
 
 
 Example 3: Get 50 rows that exclude a few columns such as city and region:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=50&exclude_columns=city,region&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?limit=50&exclude_columns=city,region&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 4: Get All Transactions from a specific time period that are of transaction_type Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27'
 
 
 Example 5: Get All Transactions from a specific time period that are of transaction_type Post Call Event:
 
  .. code-block:: bash
 
-   curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+   curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27'
 
 
 Example 6: Get All Transactions from a specific time period that are of transaction_type Call and Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
-
-Example 7: Get All Transactions from a specific time period with oauth token in the request header:
-
-.. code-block:: bash
-
-  curl -k -H 'Authorization: YbcFH' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&transaction_type[]=PostCallEVent&from=2015-03-24&to=2015-03-27'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/affiliates/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27'
 
 
 Endpoint:

--- a/source/api_documentation/transactions_api/network_user.rst
+++ b/source/api_documentation/transactions_api/network_user.rst
@@ -63,47 +63,41 @@ Example 1: Get the next 20 transactions that occurred after transaction id C624D
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=20&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 2: Get 50 rows from a specific time period with only the transaction_id and all Marketing Data columns:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=50&include_columns=transaction_id,$invoca_custom_columns&exclude_columns=$invoca_default_columns&from=2015-03-26&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=50&include_columns=transaction_id,$invoca_custom_columns&exclude_columns=$invoca_default_columns&from=2015-03-26&to=2015-03-27'
 
 
 Example 3: Get 50 rows that exclude a few columns such as Caller ID and Call Recordings:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=50&exclude_columns=calling_phone_number,recording&start_after_transaction_id=C624DA2C-CF3367C3&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?limit=50&exclude_columns=calling_phone_number,recording&start_after_transaction_id=C624DA2C-CF3367C3'
 
 
 Example 4: Get All Transactions from a specific time period that are of transaction_type Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type=Signal&from=2015-03-24&to=2015-03-27'
 
 
 Example 5: Get All Transactions from a specific time period that are of transaction_type Post Call Event:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type=PostCallEvent&from=2015-03-24&to=2015-03-27'
 
 Example 6: Get All Transactions from a specific time period that are of transaction_type Call and Signal:
 
 .. code-block:: bash
 
-  curl -k 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27&oauth_token=YbcFH'
-
-Example 7: Get All Transactions from a specific time period with oauth token in the request header:
-
-.. code-block:: bash
-
-  curl -k -H 'Authorization: YbcFH' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&transaction_type[]=PostCallEvent&from=2015-03-24&to=2015-03-27'
+  curl -k -H 'Authorization: <token>' 'https://mynetwork.invoca.net/api/@@TRANSACTION_API_VERSION/networks/transactions/33.csv?transaction_type[]=Call&transaction_type[]=Signal&from=2015-03-24&to=2015-03-27'
 
 Endpoint:
 

--- a/source/basics/design_principles.rst
+++ b/source/basics/design_principles.rst
@@ -76,44 +76,12 @@ HTTPS is required for all API requests.
 
 Authentication is performed using one of several approaches.
 
-The preferred approach is to use Invoca API tokens, which are created and managed on the Manage API Credentials page of the platform.
+The preferred approach is to use Invoca API tokens. See :doc:`manage_api_credentials` for more information.
 
 Some API endpoints will accept HTTP(S) Basic Authentication, which authenticates using a username and password in the request header.
 
 Additionally, session login authentication is sufficient as an alternative. This is so that you can
 test an API URL simply by logging in to the platform first as a Network Role of ‘Super’ (full access user) and then pasting the URL into the browser.
-
-Using OAuth token to Access Invoca APIs
----------------------------------------
-
-By default, requests are authenticated using an Invoca API Token, which can be created and managed on the "Integrations" \> "Invoca API Credentials" page in the platform.
-
-
-Step by step guide using API token to access APIs
-*************************************************
-
-1. Obtain an OAuth 2.0 token from the Manage API Credentials.
-
-2. Send the access token to an API.
-
-
-You can send the access token in a variety of ways:
-
-* **Recommended**: As an Authorization header of your request, of format `"Authorization: <token>"`
-* As a URL string parameter (for GET requests), of format `?oauth_token=<token>`
-* As a key/value pair in the JSON body (for POST requests of type JSON), of format `{ "oauth_token": "<token>", ... }`
-
-Example using Curl to make an API call with token-based authentication:
-
-.. code-block:: bash
-
-  curl -X POST -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: YbcFHZ38FNfptfZMB0RZ6dk9dOJCaCfU" 'https://\<vanity\>.invoca.net/api/@@NETWORK_API_VERSION/advertisers/1111.json'
-
-**Guidelines**
-* Users should generate their own API tokens. Tokens should be treated like passwords and not be emailed or transmitted over other insecure mediums, nor should they be stored in a source code repository.
-* As a network user, you should not generate a token on behalf of Advertisers or Publishers because tokens inherit the privileges of the user generating it.
-* Invoca does not use OAuth refresh tokens.
-
 
 
 Idempotency

--- a/source/basics/design_principles.rst
+++ b/source/basics/design_principles.rst
@@ -76,7 +76,7 @@ HTTPS is required for all API requests.
 
 Authentication is performed using one of several approaches.
 
-The preferred approach is to use Invoca API tokens. See :doc:`manage_api_credentials` for more information.
+The preferred approach is to use Invoca API tokens. See :doc:`api_documentation/manage_api_credentials` for more information.
 
 Some API endpoints will accept HTTP(S) Basic Authentication, which authenticates using a username and password in the request header.
 

--- a/source/basics/design_principles.rst
+++ b/source/basics/design_principles.rst
@@ -86,34 +86,28 @@ test an API URL simply by logging in to the platform first as a Network Role of 
 Using OAuth token to Access Invoca APIs
 ---------------------------------------
 
-
-Requests are authenticated using HTTPS basic authentication with an Invoca API Token, which can be created and managed on the Manage API Credentials page in the platform.
-
-
+By default, requests are authenticated using an Invoca API Token, which can be created and managed on the "Integrations" \> "Invoca API Credentials" page in the platform.
 
 
 Step by step guide using API token to access APIs
--------------------------------------------------
+*************************************************
 
-1. Obtain OAuth 2.0 credentials from the Manage API Credentials.
-
-   Visit your API Credentials page to obtain OAuth 2.0 credentials for your Network Integration API.
+1. Obtain an OAuth 2.0 token from the Manage API Credentials.
 
 2. Send the access token to an API.
 
 
+You can send the access token in a variety of ways:
 
-After you obtain a token, include it in the HTTP header of your request, as a URL string parameter, or as a key/value pair in the JSON body.
-
-Example using API token as URL parameter:
-
-``https://<vanity>.invoca.net/api/@@NETWORK_API_VERSION/advertisers.json?oauth_token=YbcFHZ38FNfptfZMB0RZ6dk9dOJCaCfU``
+* **Recommended**: As an Authorization header of your request, of format `"Authorization: <token>"`
+* As a URL string parameter (for GET requests), of format `?oauth_token=<token>`
+* As a key/value pair in the JSON body (for POST requests of type JSON), of format `{ "oauth_token": "<token>", ... }`
 
 Example using Curl to make an API call with token-based authentication:
 
 .. code-block:: bash
 
-  curl -X POST -H "Accept: application/json" -H "Content-Type: application/json" 'https://\<vanity\>.invoca.net/api/@@NETWORK_API_VERSION/advertisers/1111.json' -d '{"oauth_token":"YbcFHZ38FNfptfZMB0RZ6dk9dOJCaCfU"}'
+  curl -X POST -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: YbcFHZ38FNfptfZMB0RZ6dk9dOJCaCfU" 'https://\<vanity\>.invoca.net/api/@@NETWORK_API_VERSION/advertisers/1111.json'
 
 **Guidelines**
 * Users should generate their own API tokens. Tokens should be treated like passwords and not be emailed or transmitted over other insecure mediums, nor should they be stored in a source code repository.

--- a/source/basics/design_principles.rst
+++ b/source/basics/design_principles.rst
@@ -76,7 +76,7 @@ HTTPS is required for all API requests.
 
 Authentication is performed using one of several approaches.
 
-The preferred approach is to use Invoca API tokens. See :doc:`api_documentation/manage_api_credentials` for more information.
+The preferred approach is to use Invoca API tokens. See :doc:`../api_documentation/manage_api_credentials` for more information.
 
 Some API endpoints will accept HTTP(S) Basic Authentication, which authenticates using a username and password in the request header.
 


### PR DESCRIPTION
Inspired by a question from Support (which came from a customer) on the calls In Progress API ([slack thread](https://invoca.slack.com/archives/C03UN2G58UV/p1689201061221149)) - the goal is to promote the best practice of sending our API token in a header, versus as a query param that is more likely to be logged in plaintext by some client logging (or server logging on our side).

* Consolidate the two pages that talk about using Invoca API tokens for auth
* Update the copy on the new, main page describing tokens and best practices
* Change all examples to use header based auth instead of passing token in the URL or body

I'm planning to only update the latest version versus all versions (as this is not a bug fix to any specific API endpoints).


## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
