### PR TITLE
Add `pause_date` field to advertiser campaign docs

### DIFF
--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -222,9 +222,13 @@ You are not allowed to delete campaigns.
     - string
     - One of: All, None, Approved_Affiliates Default: All This controls the level of visibility publishers have when applying to campaigns.
 
+  * - pause_date
+    - string
+    - date string (ex. ‘2015-01-01 15:59:00 -0700’).
+
   * - expiration_date
     - string
-    - date string (ex. ‘2015‐01‐01’). Read only.
+    - date string. Read only. Alias of "pause_date".
 
   * - default_creative_id_from_network
     - integer


### PR DESCRIPTION
No Jira Ticket

[Slack Discussion Thread](https://invoca.slack.com/archives/C06DF8R1A/p1690501974542309)

### Demo
![image](https://github.com/Invoca/developer-docs/assets/9993068/4b582c5e-2222-4b2d-84cb-8bbdab8e10d8)

### QA
<img width="500" alt="image" src="https://github.com/Invoca/developer-docs/assets/9993068/c2963661-d053-4a24-b2a7-669ee786f805">

<img width="500" alt="image" src="https://github.com/Invoca/developer-docs/assets/9993068/e0942fe8-0fa1-42a9-ac7b-cb4874bf179c">

<img width="500" alt="image" src="https://github.com/Invoca/developer-docs/assets/9993068/64a400a5-7b0c-4957-9dbb-73f737215490">

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] ~If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)~
    - I'm being lazy for the sake of speed and only applying this to the most recent API version.
