### PR TITLE
non-production: Change conf.py to import theme manually on RTD builds

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -263,12 +263,10 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-# When building locally, the theme is not automatically imported
-# When we're not on read the docs, we have to import it and set the theme manually.
-if not on_rtd:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# The theme is not automatically imported by RTD, so we have to import manually
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_context = {}
 


### PR DESCRIPTION
Fixes a build issue for `latest` (which targets `2022-08-01`) where RTD is not providing theme options by default.

Last week, the `latest` builds were outright failing. Today, after re-triggering the `latest` build during testing, it succeeded but the theme configuration is missing. This PR addresses the issue short-term. Long-term, RTD is requiring a new configuration file and will be enforcing that in September. They've been doing periodic brownouts, removing legacy features to trigger build failures and get awareness on the issue.

RTD has removed some of the default theme settings on builds. This adds the manual theme setting back in. Everything should match the same as before.

The new branch private link is: https://developers.invoca.net/en/non-production_fix_failing_builds/api_documentation/index.html

To illustrate the issue and the fix:

The current "latest" version:
![Screenshot 2023-08-29 at 1 52 24 PM](https://github.com/Invoca/developer-docs/assets/12142496/2aa285a8-443a-489b-8fb6-cb811ddc0932)

The new branch with the build fix: 
<img width="1491" alt="Screenshot 2023-08-29 at 2 03 52 PM" src="https://github.com/Invoca/developer-docs/assets/12142496/e2c64e4d-3a65-4267-8e14-5ba1474ce7c2">

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
