### PR TITLE
TECH-12596 - Add readthedocs v2 yaml file with base configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: requirements.txt


### PR DESCRIPTION
[TECH-12596 - Create a ReadTheDocs configuration v2 YAML file](https://invoca.atlassian.net/browse/TECH-12596)

Resolves the multiple warnings on ReadTheDocs about a required new configuration file. Builds without this file present will start failing on September 25th, 2023.

Following the [steps outlined here](https://blog.readthedocs.com/migrate-configuration-v2/), I created a `.readthedocs.yaml` file with basic configuration. I changed the python version to match what is recommended in the README for local setup (Python 3.8), and I changed where `requirements.txt` is loaded from. Other than that, everything is the same from their provided example (including the OS)

🔗 Successful build for this branch, without warnings: https://readthedocs.com/projects/invoca-developer-docs/builds/1690636/

🔗 A private link for the documentation site using this branch: https://developers.invoca.net/en/tech-12596_create_config_v2_file/

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
