### PR TITLE
Update from and to query params info for TAPI

### DIFF
--- a/source/api_documentation/transactions_api/_intro.rst
+++ b/source/api_documentation/transactions_api/_intro.rst
@@ -20,10 +20,10 @@ The API takes the following optional query parameters:
     - Description
 
   * - from=
-    - Starting date in user's time zone, in format YYYY-MM-DD. Example: 2011-06-01. Inclusive.
+    - Starting date in user's time zone, in format YYYY-MM-DD. Example: 2011-06-01. Inclusive.  **Note:** When using from and to params, transactions are returned based on the associated call start time.
 
   * - to=
-    - Ending date in user's time zone, in format YYYY-MM-DD. Example: 2011-06-07. Inclusive.
+    - Ending date in user's time zone, in format YYYY-MM-DD. Example: 2011-06-07. Inclusive.  **Note:** When using from and to params, transactions are returned based on the associated call start time.
 
   * - limit=
     -  Max number of transactions to return at a time. Defaults to 1000. Limited to at most 4000.
@@ -59,7 +59,9 @@ The API takes the following optional query parameters:
     - Filters for the type of transaction. Valid inputs are Call, PostCallEvent, Sale, or Signal. Sale maps to the Reported Conversion type.
 
 In order to ensure that all transactions are returned when using the from= and to= date query parameters,
-you should store the last transaction id you have downloaded and pass it as the start_after_transaction_id to the next request.
+you should store the last transaction id you have downloaded and pass it as the start_after_transaction_id to the next request *so long as you do not change the date range*.
+Once you update the date range, the best practice is to omit the start_after_transaction_id param for the first request, then use the last transaction id you have downloaded until the date range is complete.
+This is because using from and to params sorts transactions in relation to the call start time, not the transaction time.
 Typical usage on the polling interval is to repeatedly call the API until no rows are returned, meaning you have downloaded all transactions.
 Please note, the "to" and "from" date range parameters are both necessary, providing only one or the other will not filter the results.
 


### PR DESCRIPTION
https://invoca.atlassian.net/browse/TECH-12683

Add nuance around the usage of from and to params, both about their sort and best practices in relation to `start_after_transaction_id` param.

<!-- Each Pull Request should focus on a single API family -->

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
