### PR TITLE
2022-08-01 non-production update repo readme: Update README to clarify ReadTheDocs build trigger mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,15 @@ bash html
 12. Click on your branch name to view and you should be able to check the changes you made
 13. Once you decide to make your changes public, merge your branch into an existing version branch, then delete your branch. (Only members of the Developer Docs Administrators group can push to a publically available version of the docs.)
 14. ~~ReadTheDocs will automatically pickup your changes and recompile the site.~~
-**An open issue with Read the Docs prevents this** (https://github.com/rtfd/readthedocs.org/issues/4450). There is a workaround: After creating a new branch that you want to test the documentation for, you can trigger a build of `latest` which will synchronize the versions and your new branches will appear as versions on Read the Docs.
+**[An open issue with Read the Docs prevents changes to older API version branches from being picked up automatically](https://github.com/rtfd/readthedocs.org/issues/4450).** There is a workaround: After merging your other version branch, you can trigger a build of the "latest" API version Github branch which will synchronize the versions and your new branches will appear as versions on Read the Docs. To find the "latest" API version go to https://developers.invoca.net/ and then click the version switcher at the bottom left. The latest version will be the version right after "Latest" and the version should have a matching named branch in Github.
+To trigger a build, create a new branch for the latest API version branch and then make an empty PR to merge:
+    ```
+    git switch <LATEST_API_VERSION_BRANCH_NAME>
+    git switch -c <TICKET_NUMBER>_trigger_readthedocs_build
+    git commit --allow-empty -m "Trigger ReadTheDocs Build"
+    git push
+    ```
+    Open your PR for this new branch with the empty commit and have it merged to trigger the ReadTheDocs build.
 
 ## Making a new version:
 1. Checkout the most recent branch (default) and branch off of it. E.g. Default is: 2015-12-10, branch off this, you want to bump Network integration to 2016-01-01, so name your new branch '2016-01-01')


### PR DESCRIPTION
README change (no Jira ticket) based on [this slack discussion](https://invoca.slack.com/archives/C0219D91EJU/p1695225909145699?thread_ts=1694718273.723699&cid=C0219D91EJU)

## Screenshot of README change
<img width="750" alt="image" src="https://github.com/Invoca/developer-docs/assets/9993068/bd9c7ee1-e7f6-4357-9f0e-884327ecb5ba">

## Checklist

- [ ] ~Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR~ N/A
- [ ] ~Test the documentation changes on readthedocs as a private branch~ N/A
- [ ] ~If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)~ N/A
