### PR TITLE
STORY-16600 Add default limit to number of items returned in a single request in Destinations API

### DIFF
--- a/source/api_documentation/network_integration/customer_phone_numbers/_get_customer_phone_numbers.rst
+++ b/source/api_documentation/network_integration/customer_phone_numbers/_get_customer_phone_numbers.rst
@@ -13,10 +13,6 @@
       - Type
       - Value
 
-    * - include_inactive
-      - boolean (Default true)
-      - When true, fetches all destinations. When false, fetches only destinations that have a ringpool associated with it.
-
     * - limit
       - integer (optional) (Default 100)
       - Number of objects to be returned in a single request. If not provided, first 100 objects will be returned.
@@ -29,9 +25,19 @@
       - string (optional)
       - Search string to search by phone number.
 
+        If not provided, all objects will be returned given no other filters are included.
+
     * - status
       - string (optional)
-      - To filter results by a specific type. Possible values include `ignored`, `tracked` and `discovered`.
+      - To filter results by a specific type.
+
+        If not provided, all objects will be returned given no other filters are included.
+
+        Possible values include:
+
+        * **ignored**: Fetches only destinations that were ignored.
+        * **tracked**: Fetches only destinations that have a ringpool associated with them.
+        * **discovered**: Fetches only destinations that were neither ignored nor have a ringpool associated with them.
 
     * - sort_by
       - string (optional) (Default id)

--- a/source/api_documentation/network_integration/customer_phone_numbers/_get_customer_phone_numbers.rst
+++ b/source/api_documentation/network_integration/customer_phone_numbers/_get_customer_phone_numbers.rst
@@ -2,6 +2,45 @@
 
 .. container:: endpoint-long-description
 
+  Possible options that can be provided in the API request.
+
+  .. list-table::
+    :widths: 11 34 40
+    :header-rows: 1
+    :class: parameters
+
+    * - Property
+      - Type
+      - Value
+
+    * - include_inactive
+      - boolean (Default true)
+      - When true, fetches all destinations. When false, fetches only destinations that have a ringpool associated with it.
+
+    * - limit
+      - integer (optional) (Default 100)
+      - Number of objects to be returned in a single request. If not provided, first 100 objects will be returned.
+
+    * - start
+      - integer (optional) (Default 0)
+      - First `x` number of objects to skip in the response. If not provided, the response will start from the first available object.
+
+    * - query
+      - string (optional)
+      - Search string to search by phone number.
+
+    * - status
+      - string (optional)
+      - To filter results by a specific type. Possible values include `ignored`, `tracked` and `discovered`.
+
+    * - sort_by
+      - string (optional) (Default id)
+      - Sort the result by a specific column.
+
+    * - sort_dir
+      - string (optional) (Default asc)
+      - Sorting direction for the objects being returned. Possible values include `asc` and `desc`.
+
   .. rubric:: Examples
 
   Read all Destinations as an array.


### PR DESCRIPTION
[STORY-16600 Add default limit to number of items returned in a single request in Destinations API](https://invoca.atlassian.net/browse/STORY-16600)

## Description
Add default limit to number of items returned in a single request in Destinations API

<img width="1298" alt="Screenshot 2023-11-07 at 1 01 59 AM" src="https://github.com/Invoca/developer-docs/assets/1645158/cb685fd7-bb92-4240-80e6-f5f676118cdd">


## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
