### PR TITLE
Story 16732 update endpoints to work with tag customer phone number associations

### DIFF
--- a/source/api_documentation/network_integration/customer_phone_numbers/index.rst
+++ b/source/api_documentation/network_integration/customer_phone_numbers/index.rst
@@ -93,10 +93,6 @@ Destinations are alternate way of managing :doc:`RingPools <../ringpools/index>`
     - boolean
     - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size, if numbers are available. When false, the pool will initially fill at 10% capacity to conserve phone number usage. The ringpool will increase phone numbers based on ringpool autoscaling settings and traffic volume.
 
-  * - include_inactive
-    - boolean (Default true)
-    - Only applicable for `GET /customer_phone_numbers.json` API endpoint. When true, fetches all destinations. When false, fetches only destinations that have a ringpool associated with it.
-
 Endpoint:
 
 ``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/customer_phone_numbers.json``

--- a/source/api_documentation/network_integration/js_tags/index.rst
+++ b/source/api_documentation/network_integration/js_tags/index.rst
@@ -68,22 +68,24 @@ The Invoca Tag is a snippet of code that connects Invoca to your landing pages. 
     - object
     - Current draft revision.
 
+.. raw:: html
+
+  <div class="alert alert-warning">
+    <b>Note:</b>
+    When viewing JS Tags, you will also be viewing their associated revisions.  Below is a reference for the revision and its attributes.
+    If you are looking to edit the revision itself, use the <a href="../tag_revisions/index.html"> Tag Revision API</a> instead.
+  </div>
+
 JS Tag Revision
 """"""""""""""""""""""""""""""""""""""""""""""""
 
 Revision for the JS Tag
 
-.. raw:: html
-
-    <a href="../tag_revisions/index.html">
-      Invoca Tag Revision API Documentation
-    </a>
-
 .. include:: ../tag_revisions/js_revision_parameters.rst
 
 Endpoint:
 
-``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/js_tags.json``
+``https://invoca.net/api/@@NETWORK_API_VERSION/networks/<network_id>/js_tags.json``
 
 .. api_endpoint::
    :verb: GET
@@ -148,7 +150,7 @@ Forbidden – 403:
 POST
 ----
 
-``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/js_tags.json``
+``https://invoca.net/api/@@NETWORK_API_VERSION/networks/<network_id>/js_tags.json``
 
 Content Type: application/json
 
@@ -181,7 +183,7 @@ Not Found – 404:
 GET
 ----
 
-``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/js_tags/<js_tag_id>.json``
+``https://invoca.net/api/@@NETWORK_API_VERSION/networks/<network_id>/js_tags/<js_tag_id>.json``
 
 Content Type: application/json
 

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -45,6 +45,7 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
 
   * - destination_phone_number
     - A phone number to be associated with the RingPool.
+    - Only applicable for `POST` & `PUT /ring_pools/<ring_pool_id>` API endpoint.  When using Destinations UI or the forward to destination IVR node, this number will be used.
 
   * - obfuscated_tag_id
     - string (required if the network is using Tag Destinations and a destination_phone_number is passed in)

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -45,7 +45,10 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
 
   * - destination_phone_number
     - A phone number to be associated with the RingPool.
-    - When using Destinations UI or the forward to destination IVR node, this number will be used.
+
+  * - obfuscated_tag_id
+    - string (required if the network is using Tag Destinations and a destination_phone_number is passed in)
+    - Only applicable for `POST` & `PUT /ring_pools/<ring_pool_id>` API endpoint. The Tag that will be associated with the Destination.
 
   * - fill_immediately
     - boolean


### PR DESCRIPTION
https://invoca.atlassian.net/browse/STORY-16732
![Screenshot 2023-11-22 at 10 47 06 AM](https://github.com/Invoca/developer-docs/assets/17100108/a84e163a-790d-413f-b660-fb997040ed00)

Address the new parameter introduced in https://github.com/Invoca/web/pull/22374.

Additionally, removed the explanation around the include_inactive parameter in the CustomerPhoneNumber API.  This functionality was already removed as a part of https://github.com/Invoca/web/pull/22271 where more robust and general filtering was added.

