### PR TITLE
TECH-13631: Update README to indicate ReadTheDocs fix for older API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,7 @@ bash html
 11. Click on the "latest" link in the lower left, your new branch should appear in the list of version
 12. Click on your branch name to view and you should be able to check the changes you made
 13. Once you decide to make your changes public, merge your branch into an existing version branch, then delete your branch. (Only members of the Developer Docs Administrators group can push to a publically available version of the docs.)
-14. ~~ReadTheDocs will automatically pickup your changes and recompile the site.~~
-**[An open issue with Read the Docs prevents changes to older API version branches from being picked up automatically](https://github.com/rtfd/readthedocs.org/issues/4450).** There is a workaround: After merging your other version branch, you can trigger a build of the "latest" API version Github branch which will synchronize the versions and your new branches will appear as versions on Read the Docs. To find the "latest" API version go to https://developers.invoca.net/ and then click the version switcher at the bottom left. The latest version will be the version right after "Latest" and the version should have a matching named branch in Github.
-To trigger a build, create a new branch for the latest API version branch and then make an empty PR to merge:
-    ```
-    git switch <LATEST_API_VERSION_BRANCH_NAME>
-    git switch -c <TICKET_NUMBER>_trigger_readthedocs_build
-    git commit --allow-empty -m "Trigger ReadTheDocs Build"
-    git push
-    ```
-    Open your PR for this new branch with the empty commit and have it merged to trigger the ReadTheDocs build.
+14. ReadTheDocs will automatically pickup your changes and recompile the site. (Check build status at https://readthedocs.com/projects/invoca-developer-docs/builds/)
 
 ## Making a new version:
 1. Checkout the most recent branch (default) and branch off of it. E.g. Default is: 2015-12-10, branch off this, you want to bump Network integration to 2016-01-01, so name your new branch '2016-01-01')

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [developer portal](http://developers.invoca.net) contains public documentati
 
 **IMPORTANT things to note:**
 
-1. ~~Changes made to this repo are AUTOMATICALLY picked up by RTD and published to the site.~~ **An open issue with Read the Docs prevents this** (https://github.com/rtfd/readthedocs.org/issues/4450). There is a workaround: After creating a new branch that you want to test the documentation for, you can trigger a build of `latest` which will synchronize the versions and your new branches will appear as versions on Read the Docs.
+1. Changes made to this repo are AUTOMATICALLY picked up by RTD and published to the site.
 2. The method of adding comments to API controllers is officially deprecated.
 3. General branching stratagy: Always branch off of the most recent live branch. The most recent live branch is subject to change at any time so be sure you're up to date and resolve any conflicts. If you are contributing to a new overall version (e.g. 2029-09-16) but do not own that branch, be sure to communicate with the owner about individual API versions.
 4. A branch on git maps to a "version" on read-the-docs. To create a new version (branch) and have it displayed as default,
@@ -45,8 +45,7 @@ bash html
 `bash html`
 4. Check your changes locally by opening `build/html/index.html`
 5. Commit your changes and push to GitHub (Only members of the Developer Docs Administrators group can push to a publically available version of the docs.)
-6. ~~ReadTheDocs will automatically pickup your changes and recompile the site.~~
-**An open issue with Read the Docs prevents this** (https://github.com/rtfd/readthedocs.org/issues/4450). There is a workaround: After creating a new branch that you want to test the documentation for, you can trigger a build of `latest` which will synchronize the versions and your new branches will appear as versions on Read the Docs.
+6. ReadTheDocs will automatically pickup your changes and recompile the site.(Check build status at https://readthedocs.com/projects/invoca-developer-docs/builds/)
 7. Visit https://developers.invoca.net to check your changes
 
 ## Making changes to an existing version and keeping them private:
@@ -56,8 +55,7 @@ bash html
 `bash html`
 4. Check your changes locally by opening `build/html/index.html`
 5. Commit your changes and push to GitHub
-6. ~~ReadTheDocs will automatically pickup your changes and recompile the site.~~
-**An open issue with Read the Docs prevents this** (https://github.com/rtfd/readthedocs.org/issues/4450). There is a workaround: After creating a new branch that you want to test the documentation for, you can trigger a build of `latest` which will synchronize the versions and your new branches will appear as versions on Read the Docs.
+6. ReadTheDocs will automatically pickup your changes and recompile the site.(Check build status at https://readthedocs.com/projects/invoca-developer-docs/builds/)
 7. Login to ReadTheDocs.com (credentials in lastpass)
 8. Click on the Versions button and then the Edit button next to your branch
 9. Click on the Active checkbox and set the Privacy Level to Private


### PR DESCRIPTION
Follow on to cleanup done as part of [TECH-13631](https://invoca.atlassian.net/browse/TECH-13631)

## Related PR's
* https://github.com/Invoca/developer-docs/pull/361
* https://github.com/Invoca/developer-docs/pull/359
* https://github.com/Invoca/developer-docs/pull/358
* https://github.com/Invoca/developer-docs/pull/357

## Checklist

- [ ] ~Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR~ N/A
- [ ] ~Test the documentation changes on readthedocs as a private branch~ N/A
- [ ] ~If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)~ N/A


[TECH-13631]: https://invoca.atlassian.net/browse/TECH-13631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ