### PR TITLE
TECH-13631 2019-05-01 fix jquery import

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -201,6 +201,7 @@ def setup(app):
   app.connect('source-read', source_handler)
   app.connect('html-page-context', update_body)
   app.add_js_file('js/custom.js')
+  app.add_js_file('https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js')
   app.add_js_file('https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js')
 
   # This CSS is added BEFORE the RTD CSS, so it doesn't allow us to override their CSS


### PR DESCRIPTION
Follow on work to [TECH-13631](https://invoca.atlassian.net/browse/TECH-13631) to fix jquery not being available, see [this thread for details](https://invoca.slack.com/archives/C06DF8R1A/p1703091315227529?thread_ts=1703027799.969269&cid=C06DF8R1A).

## Checklist

- [ ] ~Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR~ N/A
- [x] Test the documentation changes on readthedocs as a private branch
- [ ] ~If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)~ N/A


[TECH-13631]: https://invoca.atlassian.net/browse/TECH-13631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ