### PR TITLE
STORY-17187 Allow disabling overflow setting when creating Ringpools through RingPool API (2019-05-01)

### DIFF
--- a/source/api_documentation/network_integration/ringpools/_get_ring_pool.rst
+++ b/source/api_documentation/network_integration/ringpools/_get_ring_pool.rst
@@ -32,7 +32,8 @@
                                     "allocation_fallback_strategy": "Wait" },
       "max_pool_size": 15,
       "api_key": "value",
-      "destination_phone_number": "888-111-2222"
+      "destination_phone_number": "888-111-2222",
+      "allow_overflow": true
     }
 
   .. raw:: html

--- a/source/api_documentation/network_integration/ringpools/_get_ring_pools.rst
+++ b/source/api_documentation/network_integration/ringpools/_get_ring_pools.rst
@@ -32,7 +32,8 @@
                                       "restrict_to_state": true,
                                       "allocation_fallback_strategy": "Wait" },
         "max_pool_size": 15,
-        "api_key": "value"
+        "api_key": "value",
+        "allow_overflow": true
       }
     ]
 

--- a/source/api_documentation/network_integration/ringpools/_post_ring_pools.rst
+++ b/source/api_documentation/network_integration/ringpools/_post_ring_pools.rst
@@ -29,7 +29,8 @@
       "name": "Invoca Example RingPool",
       "max_pool_size": 15,
       "lifetime_seconds": 1800,
-      "destination_phone_number": "888-111-2222"
+      "destination_phone_number": "888-111-2222",
+      "allow_overflow": true
     }
 
   Response Code: 201

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -51,6 +51,14 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
     - boolean
     - When true, the ringpool will immediately be filled with phone numbers up to the max_pool_size, if numbers are available. When false, the pool will initially fill at 10% capacity to conserve phone number usage. The ringpool will increase phone numbers based on ringpool autoscaling settings and traffic volume.
 
+  * - allow_overflow
+    - boolean
+    - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
+
+      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may be only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
+
+      If not passed when creating a new RingPool, the RingPool will be created using the default setting of true.
+
 Endpoint:
 
 ``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>/ring_pools/<ring_pool_id_from_network>.json``
@@ -180,6 +188,12 @@ Content Type: application/json
     - array of strings
     - an array of stringified limiters on the boundaries of where to look for local numbers given as npa (ex. ["805", "212"])
 
+  * - allow_overflow
+    - boolean
+    - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
+
+      If not passed, the RingPool will be created using the default setting of true.
+
 Response Code: 200
 
 **Request Body**
@@ -193,7 +207,8 @@ Response Code: 200
    "max_pool_size": "3",
    "local_center": {"latitude": 45, "longitude": 45},
    "tn_prefix_whitelist": ["455"],
-   "destination_phone_number": "888-111-2222"
+   "destination_phone_number": "888-111-2222",
+   "allow_overflow": false
   }
 
 **Response Body**

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -55,7 +55,7 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
     - boolean
     - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
 
-      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may be only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
+      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
 
       If not passed when creating a new RingPool, the RingPool will be created using the default setting of true.
 


### PR DESCRIPTION
[Allow disabling overflow setting when creating Ringpools through RingPool API](https://invoca.atlassian.net/browse/STORY-17187)

Focusing on API version `2109-05-01`, updating the Developer Docs to include information about the new `allow_overflow` field for creating and viewing RingPools.

Changes:
![Invoca_Developer_Portal](https://github.com/Invoca/developer-docs/assets/5199314/5d756fc3-5ce9-4097-b8e7-5d7bae50f489)
![Invoca_Developer_Portal - get_pools](https://github.com/Invoca/developer-docs/assets/5199314/aeee3ab4-b828-4544-91f0-a0c0f1dda0a6)
![Invoca_Developer_Portal - get_pool](https://github.com/Invoca/developer-docs/assets/5199314/894c5e5d-a6d8-422d-b322-e2277dac0395)
![Invoca_Developer_Portal-post](https://github.com/Invoca/developer-docs/assets/5199314/3a50b4e2-db2c-468f-a2d1-41e9a5cb48ed)
![Invoca_Developer_Portal-local_ringpool_port](https://github.com/Invoca/developer-docs/assets/5199314/8a545a0f-a4b2-4aea-824c-d1d411016c44)


## Checklist

- [X] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [X] Test the documentation changes on readthedocs as a private branch
- [X] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
  - [X] [2020-10-01](https://github.com/Invoca/developer-docs/pull/368)
  - [X] [2022-03-01](https://github.com/Invoca/developer-docs/pull/369)
  - [X] [2022-08-01](https://github.com/Invoca/developer-docs/pull/370)
