### PR TITLE
STORY-17187 Allow disabling overflow setting when creating Ringpools through RingPool API (2022-08-01) 

### DIFF
--- a/source/api_documentation/network_integration/ringpools/_get_ring_pool.rst
+++ b/source/api_documentation/network_integration/ringpools/_get_ring_pool.rst
@@ -32,6 +32,7 @@
                                     "allocation_fallback_strategy": "Wait" },
       "max_pool_size": 15,
       "api_key": "value",
-      "destination_phone_number": "888-111-2222"
+      "destination_phone_number": "888-111-2222",
+      "allow_overflow": true
     }
 

--- a/source/api_documentation/network_integration/ringpools/_get_ring_pools.rst
+++ b/source/api_documentation/network_integration/ringpools/_get_ring_pools.rst
@@ -32,7 +32,8 @@
                                       "restrict_to_state": true,
                                       "allocation_fallback_strategy": "Wait" },
         "max_pool_size": 15,
-        "api_key": "value"
+        "api_key": "value",
+        "allow_overflow": true
       }
     ]
 

--- a/source/api_documentation/network_integration/ringpools/_post_ring_pools.rst
+++ b/source/api_documentation/network_integration/ringpools/_post_ring_pools.rst
@@ -29,7 +29,8 @@
       "name": "Invoca Example RingPool",
       "max_pool_size": 15,
       "lifetime_seconds": 1800,
-      "destination_phone_number": "888-111-2222"
+      "destination_phone_number": "888-111-2222",
+      "allow_overflow": true
     }
 
   Response Code: 201

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -59,6 +59,14 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
     - boolean (Default false)
     - Only applicable for `DELETE /ring_pools/<ring_pool_id>` API endpoint. When true, it deletes the linked :doc:`destinations <../customer_phone_numbers/index>` as well. When false, the destinations are kept as is.
 
+  * - allow_overflow
+    - boolean
+    - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
+
+      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may be only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
+
+      If not passed when creating a new RingPool, the RingPool will be created using the default setting of true.
+
 Endpoint:
 
 ``https://invoca.net/api/@@NETWORK_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>/ring_pools/<ring_pool_id_from_network>.json``
@@ -200,6 +208,12 @@ Content Type: application/json
     - array of strings
     - an array of stringified limiters on the boundaries of where to look for local numbers given as npa (ex. ["805", "212"])
 
+  * - allow_overflow
+    - boolean
+    - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
+
+      If not passed, the RingPool will be created using the default setting of true.
+
 Response Code: 200
 
 **Request Body**
@@ -213,7 +227,8 @@ Response Code: 200
    "max_pool_size": "3",
    "local_center": {"latitude": 45, "longitude": 45},
    "tn_prefix_whitelist": ["455"],
-   "destination_phone_number": "888-111-2222"
+   "destination_phone_number": "888-111-2222",
+   "allow_overflow": false
   }
 
 **Response Body**

--- a/source/api_documentation/network_integration/ringpools/index.rst
+++ b/source/api_documentation/network_integration/ringpools/index.rst
@@ -63,7 +63,7 @@ By default, RingPools will capture params based on your Marketing Data Dictionar
     - boolean
     - Determines what should happen if visitor traffic exceeds the pool size.  When true, the RingPool will reserve one phone number for "overflow" and apply it to any additional visitors.  When false, the destination phone number will not be replaced on the website.
 
-      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may be only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
+      This field can be passed with a value of true or false when creating a RingPool. If updating a RingPool, the field may only be provided if the value is the same as when it was created (i.e. no change). If trying to change the value on an update request, the request will fail.
 
       If not passed when creating a new RingPool, the RingPool will be created using the default setting of true.
 


### PR DESCRIPTION
[Allow disabling overflow setting when creating Ringpools through RingPool API](https://invoca.atlassian.net/browse/STORY-17187)

Focusing on API version `2022-08-01`, updating the Developer Docs to include information about the new `allow_overflow` field for creating and viewing RingPools.

See PR #367 for ticket details.

## Checklist

- [X] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [X] Test the documentation changes on readthedocs as a private branch
- [X] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
  - [X] [2019-05-01](https://github.com/Invoca/developer-docs/pull/367)
  - [X] [2020-10-01](https://github.com/Invoca/developer-docs/pull/368)
  - [X] [2022-03-01](https://github.com/Invoca/developer-docs/pull/369)