### PR TITLE
STORY-11379: remove another reference to CRAPI

### DIFF
--- a/source/api_documentation/index.rst
+++ b/source/api_documentation/index.rst
@@ -31,8 +31,6 @@ used for SMS number management, as well as handling incoming/outgoing SMS messag
 
 The Transactions API and Network Integration API are accessible using the API credentials generated on the platform. See :doc:`manage_api_credentials` for more information.
 
-The Conversion Reporting API is accessible using credentials provided by Invoca. Submit a case via the `Community Case Portal`_ to request Conversion Reporting API credentials.
-
 The RingPool and Bulk RingPool APIs are accessible using the API keys provided in the RingPool wizard. (Note: the Bulk RingPool API is only available after being enabled by Customer Success. Submit a case via the `Community Case Portal`_ to request the Bulk RingPool API.)
 
 .. _`Community Case Portal`: https://community.invoca.com/t5/crmsupport/page


### PR DESCRIPTION
Remove additional verbiage that is referencing the conversion reporting api

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
