### PR TITLE
JETS-255: Add call record ID search to CIP API docs

### DIFF
--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id.rst
@@ -1,0 +1,94 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Example
+
+  Get calls in progress for call record id `Z6E5-C7397356976E`.
+  Be sure to use your own organization_type and id.
+
+  This can return multiple results if there are multiple transactions for the call in progress.
+
+  `current_calls` will be ordered by `bridge_start_time`, most recent first.
+
+  Endpoint:
+
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>&call_record_id=Z6E5-C7397356976E``
+
+  Parameters: `call_record_id` is required for this request
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+      "current_calls": [
+        {
+          "transaction_id": "ABCD1234-ABCD1234",
+          "call_status": "bridged",
+          "external_unique_id": null,
+          "calling_phone_number": "+15559999999",
+          "destination_phone_number": "+18555595599",
+          "called_phone_number": "+18557174046",
+          "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
+          "phone_type": "Mobile",
+          "advertiser_campaign_country": "USA",
+          "advertiser_campaign_id": "SampleCampaignID-123",
+          "advertiser_campaign_id_from_network": "NetworkCampaignID-456",
+          "advertiser_campaign_name": "Sample Campaign Name",
+          "advertiser_id": "AdvertiserID-789",
+          "advertiser_id_from_network": "NetworkAdvertiserID-012",
+          "advertiser_name": "Sample Advertiser Name",
+          "affiliate_campaign_id_from_network": "NetworkAffiliateCampaignID-345",
+          "affiliate_commissions_ranking": "Top 10%",
+          "affiliate_conversion_rate_ranking": "Top 20%",
+          "affiliate_id": "AffiliateID-678",
+          "affiliate_id_from_network": "NetworkAffiliateID-901",
+          "affiliate_name": "Sample Affiliate Name",
+          "affiliate_volume_ranking": "Top 5%",
+          "city": "New York",
+          "destination_phone_number": "+18555555555",
+          "external_unique_id": "ExternalID-234",
+          "keypress_1": "1",
+          "keypress_2": "2",
+          "keypress_3": "3",
+          "keypress_4": "4",
+          "key presses": "1,2,3,4",
+          "media_type": "Online",
+          "phone_type": "Mobile",
+          "promo_number_description": "Sample Promo Description",
+          "promo_number_id": "PromoID-567",
+          "qualified_regions": "East Coast",
+          "region": "North East",
+          "source": "Web",
+          "start_time": "2023-04-03T16:00:00-07:00",
+          "transaction_id": "TransactionID-890",
+          "verified_zip_code": "10001",
+          "zip_code": "10001"
+          "custom_data": {
+                "utm_source": {
+                    "value": "google.com",
+                    "source": "VirtualLine"
+                },
+                "calling_page": {
+                    "value": "https://www.doggydaycare.com/boarding",
+                    "source": "DynamicAttribution"
+                },
+                "g_cid": {
+                    "value": "asdf-1234-zxcv-5678",
+                    "source": "DynamicAttribution"
+                },
+                "channel": {
+                    "value": "SEM",
+                    "source": "DynamicAttribution"
+                },
+                "lead_type": {
+                    "value": "StoreCall",
+                    "source": "VirtualLine"
+                },
+                "demographics_data": {}
+            }
+        }
+      ]
+    }

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id_for_attribution.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id_for_attribution.rst
@@ -1,0 +1,38 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Example
+
+  Get calls in progress for call record id `Z6E5-C7397356976E`.
+  Be sure to use your own organization_type and id.
+
+  This can return multiple results if there are multiple transactions for the call in progress.
+
+  `current_calls` will be ordered by `bridge_start_time`, most recent first.
+
+  Endpoint:
+
+  ``https://invoca.net/api/@@CALLS_IN_PROGRESS_API_VERSION/calls_in_progress/current_calls.json?id=<organization_id>&organization_type=<organization_type>&call_record_id=Z6E5-C7397356976E``
+
+  Parameters: `call_record_id` is required for this request
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+      "current_calls": [
+        {
+          "transaction_id": "ABCD1234-ABCD1234",
+          "call_status": "bridged",
+          "external_unique_id": null,
+          "calling_phone_number": "+15559999999",
+          "destination_phone_number": "+18555595599",
+          "called_phone_number": "+18557174046",
+          "bridge_start_time": "2023-04-03T16:02:36-07:00",
+          "call_record_id": "Z6E5-C7397356976E",
+          "phone_type": "Mobile",
+        }
+      ]
+    }

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id_for_attribution.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_call_record_id_for_attribution.rst
@@ -32,7 +32,6 @@
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
           "call_record_id": "Z6E5-C7397356976E",
-          "phone_type": "Mobile",
         }
       ]
     }

--- a/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id_for_attribution.rst
+++ b/source/api_documentation/calls_in_progress_api/_get_calls_by_transaction_id_for_attribution.rst
@@ -30,7 +30,6 @@
           "called_phone_number": "+18557174046",
           "bridge_start_time": "2023-04-03T16:02:36-07:00",
           "call_record_id": "Z6E5-C7397356976E",
-          "phone_type": "Mobile",
         }
       ]
     }

--- a/source/api_documentation/calls_in_progress_api/index.rst
+++ b/source/api_documentation/calls_in_progress_api/index.rst
@@ -101,8 +101,8 @@ Examples
 .. api_endpoint::
    :verb: GET
    :path: /calls_in_progress/current_calls
-   :description: Get calls in progress by calling and destination phone numbers
-   :page: get_calls_by_phone_number
+   :description: Get calls in progress by call record id
+   :page: get_calls_by_call_record_id
 
 
 .. api_endpoint::
@@ -115,8 +115,8 @@ Examples
 .. api_endpoint::
    :verb: GET
    :path: /calls_in_progress/current_calls
-   :description: Get calls in progress by call record id
-   :page: get_calls_by_call_record_id
+   :description: Get calls in progress by calling and destination phone numbers
+   :page: get_calls_by_phone_number
 
 
 Using the API for Attribution

--- a/source/api_documentation/calls_in_progress_api/index.rst
+++ b/source/api_documentation/calls_in_progress_api/index.rst
@@ -142,6 +142,12 @@ Examples
    :description: Retrieve a specific call by Transaction ID
    :page: get_calls_by_transaction_id_for_attribution
 
+.. api_endpoint::
+   :verb: GET
+   :path: /calls_in_progress
+   :description: Retrieve a specific call by Call Record ID
+   :page: get_calls_by_call_record_id_for_attribution
+
 Response Codes
 --------------
 

--- a/source/api_documentation/calls_in_progress_api/index.rst
+++ b/source/api_documentation/calls_in_progress_api/index.rst
@@ -55,6 +55,11 @@ Query Parameters
     - String
     - Optional
 
+  * - call_record_id
+    - The call record id for the desired call
+    - String
+    - Optional
+
   * - external_unique_id
     - The unique id previously applied to the desired call
     - String
@@ -105,6 +110,13 @@ Examples
    :path: /calls_in_progress/current_calls
    :description: Get calls in progress by external unique id
    :page: get_calls_by_external_unique_id
+
+
+.. api_endpoint::
+   :verb: GET
+   :path: /calls_in_progress/current_calls
+   :description: Get calls in progress by call record id
+   :page: get_calls_by_call_record_id
 
 
 Using the API for Attribution


### PR DESCRIPTION
# JETS-255 (https://invoca.atlassian.net/browse/JETS-255)

Adds documentation for existing functionality to query on Call Record ID for Calls in Progress API.

Note: Calls in Progress API is only available on 2022-08-01 branch/docs.

![Screenshot 2025-06-09 at 3 28 54 PM](https://github.com/user-attachments/assets/235d5bcf-38b2-4571-ac42-3926171f7cb0)
![Screenshot 2025-06-09 at 3 29 14 PM](https://github.com/user-attachments/assets/edf0fb4f-a910-45cf-98d3-32de09892e80)
![Screenshot 2025-06-09 at 3 29 31 PM](https://github.com/user-attachments/assets/50249ad2-23a4-4a93-bb7c-146d04ddf5fc)


## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [x] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
