### PR TITLE
STORY-22329: Deprecate performance notification fields

### DIFF
--- a/source/api_documentation/network_integration/advertiser_users/_get_advertiser_user.rst
+++ b/source/api_documentation/network_integration/advertiser_users/_get_advertiser_user.rst
@@ -35,7 +35,7 @@
        "notify_on_creative_duplication_requests": true,
        "notify_on_network_announcements": true,
        "notify_on_performance_notifications": false,
-       "notify_on_monthly_campaign_performance_reports": true,
+       "notify_on_monthly_campaign_performance_reports": false,
        "notify_on_weekly_campaign_performance_reports": false,
        "notify_on_call_activities": true,
        "can_login_via_platform": false

--- a/source/api_documentation/network_integration/advertiser_users/_get_advertiser_users.rst
+++ b/source/api_documentation/network_integration/advertiser_users/_get_advertiser_users.rst
@@ -36,7 +36,7 @@
          "notify_on_creative_duplication_requests": true,
          "notify_on_network_announcements": true,
          "notify_on_performance_notifications": false,
-         "notify_on_monthly_campaign_performance_reports": true,
+         "notify_on_monthly_campaign_performance_reports": false,
          "notify_on_weekly_campaign_performance_reports": false,
          "notify_on_call_activities": true,
          "can_login_via_platform": false

--- a/source/api_documentation/network_integration/advertiser_users/_post_advertiser_users.rst
+++ b/source/api_documentation/network_integration/advertiser_users/_post_advertiser_users.rst
@@ -30,9 +30,6 @@
          "notify_on_campaign_expirations": false,
          "notify_on_creative_duplication_requests": true,
          "notify_on_network_announcements": true,
-         "notify_on_performance_notifications": false,
-         "notify_on_monthly_campaign_performance_reports": true,
-         "notify_on_weekly_campaign_performance_reports": false,
          "notify_on_call_activities": true
        }
      }

--- a/source/api_documentation/network_integration/advertiser_users/_put_advertiser_user.rst
+++ b/source/api_documentation/network_integration/advertiser_users/_put_advertiser_user.rst
@@ -31,9 +31,6 @@
          "notify_on_campaign_expirations": false,
          "notify_on_creative_duplication_requests": true,
          "notify_on_network_announcements": true,
-         "notify_on_performance_notifications": false,
-         "notify_on_monthly_campaign_performance_reports": true,
-         "notify_on_weekly_campaign_performance_reports": false,
          "notify_on_call_activities": true
        }
      }

--- a/source/api_documentation/network_integration/advertisers/_get_advertiser.rst
+++ b/source/api_documentation/network_integration/advertisers/_get_advertiser.rst
@@ -52,7 +52,7 @@
            "notify_on_creative_duplication_requests": true,
            "notify_on_network_announcements": true,
            "notify_on_performance_notifications": false,
-           "notify_on_monthly_campaign_performance_reports": true,
+           "notify_on_monthly_campaign_performance_reports": false,
            "notify_on_weekly_campaign_performance_reports": false,
            "notify_on_call_activities": true,
            "can_login_via_platform": false
@@ -73,7 +73,7 @@
            "notify_on_creative_duplication_requests": true,
            "notify_on_network_announcements": true,
            "notify_on_performance_notifications": false,
-           "notify_on_monthly_campaign_performance_reports": true,
+           "notify_on_monthly_campaign_performance_reports": false,
            "notify_on_weekly_campaign_performance_reports": false,
            "notify_on_call_activities": true,
            "can_login_via_platform": true

--- a/source/api_documentation/network_integration/advertisers/_get_advertisers.rst
+++ b/source/api_documentation/network_integration/advertisers/_get_advertisers.rst
@@ -49,7 +49,7 @@
              "notify_on_creative_duplication_requests": true,
              "notify_on_network_announcements": true,
              "notify_on_performance_notifications": false,
-             "notify_on_monthly_campaign_performance_reports": true,
+             "notify_on_monthly_campaign_performance_reports": false,
              "notify_on_weekly_campaign_performance_reports": false,
              "notify_on_call_activities": true,
              "can_login_via_platform": true

--- a/source/api_documentation/network_integration/advertisers/_post_advertiser.rst
+++ b/source/api_documentation/network_integration/advertisers/_post_advertiser.rst
@@ -39,9 +39,6 @@
            "notify_on_campaign_expirations": false,
            "notify_on_creative_duplication_requests": true,
            "notify_on_network_announcements": true,
-           "notify_on_performance_notifications": false,
-           "notify_on_monthly_campaign_performance_reports": true,
-           "notify_on_weekly_campaign_performance_reports": false,
            "notify_on_call_activities": true
          },
          {
@@ -59,9 +56,6 @@
            "notify_on_campaign_expirations": false,
            "notify_on_creative_duplication_requests": true,
            "notify_on_network_announcements": true,
-           "notify_on_performance_notifications": false,
-           "notify_on_monthly_campaign_performance_reports": true,
-           "notify_on_weekly_campaign_performance_reports": false,
            "notify_on_call_activities": true
          }
        ],

--- a/source/api_documentation/network_integration/advertisers/_put_advertiser.rst
+++ b/source/api_documentation/network_integration/advertisers/_put_advertiser.rst
@@ -38,9 +38,6 @@
            "notify_on_campaign_expirations": false,
            "notify_on_creative_duplication_requests": true,
            "notify_on_network_announcements": true,
-           "notify_on_performance_notifications": false,
-           "notify_on_monthly_campaign_performance_reports": true,
-           "notify_on_weekly_campaign_performance_reports": false,
            "notify_on_call_activities": true
          }
        ],

--- a/source/api_documentation/network_integration/advertisers/index.rst
+++ b/source/api_documentation/network_integration/advertisers/index.rst
@@ -117,15 +117,15 @@ You are not allowed to delete an advertiser if it has one or more campaigns.
     -
 
   * - notify_on_performance_notifications
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_monthly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_weekly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_call_activities

--- a/source/api_documentation/network_integration/affiliates/_get_affiliate.rst
+++ b/source/api_documentation/network_integration/affiliates/_get_affiliate.rst
@@ -46,7 +46,7 @@
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
           "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
+          "notify_on_monthly_campaign_performance_reports": false,
           "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true,
           "can_login_via_platform": true

--- a/source/api_documentation/network_integration/affiliates/_get_affiliates.rst
+++ b/source/api_documentation/network_integration/affiliates/_get_affiliates.rst
@@ -47,7 +47,7 @@
             "notify_on_creative_duplication_requests": true,
             "notify_on_network_announcements": true,
             "notify_on_performance_notifications": false,
-            "notify_on_monthly_campaign_performance_reports": true,
+            "notify_on_monthly_campaign_performance_reports": false,
             "notify_on_weekly_campaign_performance_reports": false,
             "notify_on_call_activities": true,
             "can_login_via_platform": true

--- a/source/api_documentation/network_integration/affiliates/_post_affiliate.rst
+++ b/source/api_documentation/network_integration/affiliates/_post_affiliate.rst
@@ -35,9 +35,6 @@
           "notify_on_campaign_expirations": false,
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
-          "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
-          "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true
         }
       ],

--- a/source/api_documentation/network_integration/affiliates/index.rst
+++ b/source/api_documentation/network_integration/affiliates/index.rst
@@ -105,15 +105,15 @@ Similar to advertisers, you are not allowed to delete if one or more campaigns e
     -
 
   * - notify_on_performance_notifications
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_monthly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_weekly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_call_activities

--- a/source/api_documentation/network_integration/networks/_get_network.rst
+++ b/source/api_documentation/network_integration/networks/_get_network.rst
@@ -37,7 +37,7 @@
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
           "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
+          "notify_on_monthly_campaign_performance_reports": false,
           "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true,
           "can_login_via_platform": false
@@ -56,7 +56,7 @@
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
           "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
+          "notify_on_monthly_campaign_performance_reports": false,
           "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true,
           "can_login_via_platform": false

--- a/source/api_documentation/network_integration/networks/_post_network_users.rst
+++ b/source/api_documentation/network_integration/networks/_post_network_users.rst
@@ -32,9 +32,6 @@
           "notify_on_campaign_expirations": false,
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
-          "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
-          "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true
         },
         {
@@ -49,9 +46,6 @@
           "notify_on_campaign_expirations": false,
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
-          "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
-          "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true
         }
       ]

--- a/source/api_documentation/network_integration/networks/_put_network_user.rst
+++ b/source/api_documentation/network_integration/networks/_put_network_user.rst
@@ -32,9 +32,6 @@
           "notify_on_campaign_expirations": false,
           "notify_on_creative_duplication_requests": true,
           "notify_on_network_announcements": true,
-          "notify_on_performance_notifications": false,
-          "notify_on_monthly_campaign_performance_reports": true,
-          "notify_on_weekly_campaign_performance_reports": false,
           "notify_on_call_activities": true
         }
       ]

--- a/source/api_documentation/network_integration/networks/index.rst
+++ b/source/api_documentation/network_integration/networks/index.rst
@@ -80,15 +80,15 @@ Parameters
     -
 
   * - notify_on_performance_notifications
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_monthly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_weekly_campaign_performance_reports
-    - boolean, optional, defaults to false
+    - Deprecated, always returns false
     -
 
   * - notify_on_call_activities


### PR DESCRIPTION
https://invoca.atlassian.net/browse/STORY-22329

Omega has deprecated performance notifications. These fields currently always return false from the deprecation work. We are now updating the documentation to indicate the API's current behavior.

<!-- Each Pull Request should focus on a single API family -->

## Checklist

- [x] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)
