### PR TITLE
RANG-193: Remove Readspeaker TTS voices from documentation 2022-03-01 

### DIFF
--- a/source/api_documentation/network_integration/prompt_voice/index.rst
+++ b/source/api_documentation/network_integration/prompt_voice/index.rst
@@ -13,8 +13,6 @@ Set Prompt Voice
 
 To use a particular prompt voice for your campaign, set ``"tts_voice_talent_id"`` on the IVR. See the tables in the **Conditions** section below to determine which prompt voice to use. (Make sure to reference *only* the table that corresponds to the language of your campaign.)
 
-If no voice is provided, a default voice will be selected based on the Campaign Country.
-
 POST
 
 ``https://invoca.net/api/@@CAMPAIGN_FEATURES_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>.json``

--- a/source/api_documentation/network_integration/prompt_voice/index.rst
+++ b/source/api_documentation/network_integration/prompt_voice/index.rst
@@ -13,6 +13,8 @@ Set Prompt Voice
 
 To use a particular prompt voice for your campaign, set ``"tts_voice_talent_id"`` on the IVR. See the tables in the **Conditions** section below to determine which prompt voice to use. (Make sure to reference *only* the table that corresponds to the language of your campaign.)
 
+If no voice is provided, a default voice will be selected based on the Campaign Country.
+
 POST
 
 ``https://invoca.net/api/@@CAMPAIGN_FEATURES_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>.json``
@@ -48,16 +50,6 @@ English voice options
     - Voice Name
     - Gender
     - Language code (Country)
-
-  * - 3 (Default)
-    - Julie
-    - Female
-    - en-US (United States)
-
-  * - 7
-    - Bridget
-    - Female
-    - en-UK (United Kingdom)
 
   * - 8
     - Nicole


### PR DESCRIPTION
Default prompt voices are not indicated. Instead, added a text to explain that defaults are selected based on the campaign country.

[RANG-193](https://invoca.atlassian.net/browse/RANG-193)

## PRs for other API versions
* #415
* #416
* #417
* #418
* #419

## Checklist

- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
- [ ] Test the documentation changes on readthedocs as a private branch
- [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)


[RANG-193]: https://invoca.atlassian.net/browse/RANG-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ