### PR TITLE
BARN-377: Clarify NIAPI Advertiser Campaign docs (required params, upsert, custom_data types)

### DIFF
--- a/source/api_documentation/network_integration/advertiser_campaigns/_post_advertiser_campaign.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/_post_advertiser_campaign.rst
@@ -2,6 +2,10 @@
 
 .. container:: endpoint-long-description
 
+  .. rubric:: Behavior
+
+  Creating a campaign requires a ``name`` (and an ``id_from_network``, unless the network is configured to auto-generate ids).
+
   .. rubric:: Examples
 
   Create Campaign fJauFbSEGHKw8ADEGv for Advertiser cFUyYnFHyiYA42TrpM

--- a/source/api_documentation/network_integration/advertiser_campaigns/_put_advertiser_campaign.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/_put_advertiser_campaign.rst
@@ -2,6 +2,10 @@
 
 .. container:: endpoint-long-description
 
+  .. rubric:: Behavior
+
+  The campaign to update is identified by the ``<advertiser_campaign_id_from_network>`` in the URL, which is matched against the campaign's ``id_from_network``. If a campaign with that id exists for the advertiser, it is updated. **If no campaign with that id exists, a new campaign is created** ("upsert"). Because creating a campaign requires a ``name``, a PUT against a non-existent id will fail unless ``name`` is included in the request body. To update an existing campaign, omit ``name`` (or send its current value) and the campaign's name is left unchanged.
+
   .. rubric:: Examples
 
   Example IVR Tree updates:

--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -7,6 +7,8 @@ Note that the `<advertiser_id_from_network>` and `<advertiser_campaign_id_from_n
 
 ``/api/@@NETWORK_API_VERSION/<network_id>/advertisers/<advertiser_id_from_network>/advertiser_campaigns/<advertiser_campaign_id_from_network>.json``
 
+The ``<advertiser_campaign_id_from_network>`` in the URL — shown as ``<advertiser_campaign_id>`` in the endpoint paths below — is the **lookup key** used to find an existing advertiser campaign; it is matched against the campaign's ``id_from_network``. A **PUT** to this URL is an "upsert": if a campaign with that id already exists for the advertiser it is updated; if it does not exist, a new campaign is created. Because a new campaign requires a ``name``, a PUT to an id that does not yet exist must include a ``name``. See the POST and PUT endpoint sections below for details.
+
 We support passing back current_terms and future_terms on campaigns. The current properties of the campaign are reflected in current_terms. All changes to the campaign are staged in future_terms. Once the campaign goes live, future_terms transition over to current_terms.
 
 You can set budgets on your campaign. There are three budget types, budget_cap_alert which is based on commissions, periodic_call_cap_alert, which is based on the number of calls in a given period, and concurrent_call_cap_alert, which is based on the number of simultaneous calls. These budget activities are only applicable for AffiliateEnabled campaigns (Known in the platform as a “Publisher Promotion” Campaign Type.)
@@ -27,12 +29,12 @@ You are not allowed to delete campaigns.
     - The internal Invoca id for this Advertiser Campaign.
 
   * - id_from_network
-    - string
-    - The network object_id for this Advertiser Campaign. Unique within network. Not required when auto-generation is enabled at network level.
+    - string (required)
+    - The network object_id for this Advertiser Campaign. Unique within network. Used as the lookup key to find an existing campaign (see above). Not required when auto-generation is enabled at network level.
 
   * - name
-    - string
-    - Campaign name.
+    - string (required on create)
+    - Campaign name. Required when creating a new campaign. Optional on update, where it defaults to the existing name.
 
   * - campaign_type
     - string

--- a/source/api_documentation/network_integration/advertiser_campaigns/index.rst
+++ b/source/api_documentation/network_integration/advertiser_campaigns/index.rst
@@ -741,6 +741,33 @@ For the following example, we would apply the value "Offline newspaper" to the C
     }
   }
 
+**Value types**
+
+Every value in ``custom_data`` must be sent as a JSON **string**, or ``null`` to clear the field — including values that are conceptually true/false or numeric. Quote them:
+
+* ``"is_member": "true"`` — not ``"is_member": true``
+* ``"order_count": "5"`` — not ``"order_count": 5``
+
+A non-string value (such as an unquoted boolean or number) is rejected with an error of the form:
+
+.. code-block:: json
+
+  {
+    "error": {
+      "invalid_data": "custom_data field '<partner_name>' value must be a string or null"
+    }
+  }
+
+Only Custom Data Fields whose type is ``string`` (Short Text), ``url`` (Long Text), or ``business_object`` (Category) can be set via ``custom_data``. Targeting a field of any other type — for example a Boolean or Score field — is rejected with an error of the form:
+
+.. code-block:: json
+
+  {
+    "error": {
+      "invalid_data": "custom_data field '<partner_name>' has unsupported type '<type>'; supported types are 'string', 'url', and 'business_object'"
+    }
+  }
+
 
 Endpoint:
 


### PR DESCRIPTION
## Summary

Documentation updates for the NIAPI **Advertiser Campaigns** endpoints, following the Starkey escalation ([ESCALATION-217](https://invoca.atlassian.net/browse/ESCALATION-217)) where an under-specified contract caused confusion. Closes [BARN-377](https://invoca.atlassian.net/browse/BARN-377).

All claims were verified against the actual NIAPI implementation in the `web` repo (controller/DTO/`ApiCustomDataOwner`), not just the escalation thread.

## Changes (3 atomic commits)

1. **Required params & lookup key** — Mark `id_from_network` and `name` as required in the properties table; explain that `<advertiser_campaign_id_from_network>` in the URL is the lookup key used by create (POST) and update (PUT).
2. **PUT/POST upsert behavior** — Add `Behavior` notes: a request keyed on a non-existent id creates a new campaign (requiring `name`); an existing id is updated, not duplicated. This is the root of the Starkey `name` error.
3. **`custom_data` value-type contract** — Values must be strings (or `null`); non-string values are now rejected. Documents the supported field types (`string`, `url`, `business_object`) and the `invalid_data` error returned. This is the root of the `is_sproutloud` break.

## Acceptance criteria coverage

- [x] Required vs optional params called out
- [x] Search/lookup params documented (`advertiser_campaign_id_from_network`)
- [x] PUT-creates-on-missing behavior clarified
- [x] `custom_data` value types documented
- [x] Reviewed adjacent advertiser-campaign docs for similar ambiguities (none found)

> AC5's internal versioning/communication-process guidance was intentionally left out of the public portal — it belongs on the ticket as a process follow-up, not in developer-facing docs.

## Verification

Built locally with Sphinx (`bash html`). The Advertiser Campaigns page builds with **no warnings/errors**, and the properties table renders correctly (the silent-failure risk for RST tables). Note: local build used Python 3.12/Sphinx 9 (the README-pinned 3.8 fails to compile on macOS 26); ReadTheDocs builds on 3.8, so confirm the rendered result on the RTD preview as final QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ESCALATION-217]: https://invoca.atlassian.net/browse/ESCALATION-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BARN-377]: https://invoca.atlassian.net/browse/BARN-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ