### PR TITLE
MON-22: Document v2 /transcript_analysis endpoint

### DIFF
--- a/source/api_documentation/call_api/_get_call_transcript_analysis_v2_available.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_analysis_v2_available.rst
@@ -1,0 +1,31 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript analysis for the given call record `CUID-33` where both the summary and sentiment are available
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/v2/transcript_analysis/CUID-33``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+       "call_record_id": "CUID-33",
+       "transcript_summary": {
+          "status": "available",
+          "text": "The customer was looking to purchase a new vehicle."
+       },
+       "sentiment": {
+          "status": "available",
+          "overall": { "score": 0.42, "label": "positive" },
+          "agent":   { "score": 0.55, "label": "positive" },
+          "caller":  { "score": 0.31, "label": "neutral" }
+       }
+    }

--- a/source/api_documentation/call_api/_get_call_transcript_analysis_v2_pending.rst
+++ b/source/api_documentation/call_api/_get_call_transcript_analysis_v2_pending.rst
@@ -1,0 +1,27 @@
+.. container:: endpoint-long-description
+
+  .. rubric:: Examples
+
+  Get transcript analysis for the given call record `CUID-33` where the summary is still pending and sentiment analysis is not enabled
+
+  Endpoint:
+
+  ``https://mynetwork.invoca.net/call/v2/transcript_analysis/CUID-33``
+
+  Format: application/json
+
+  Response Code: 200
+
+  Response Body:
+
+  .. code-block:: json
+
+    {
+       "call_record_id": "CUID-33",
+       "transcript_summary": {
+          "status": "pending"
+       },
+       "sentiment": {
+          "status": "not_applicable"
+       }
+    }

--- a/source/api_documentation/call_api/index.rst
+++ b/source/api_documentation/call_api/index.rst
@@ -20,3 +20,11 @@ The data returned depends on the request and query paramaters. To see which fiel
    :hidden:
 
    transcript_analysis_api
+
+:doc:`transcript_analysis_v2_api`
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   transcript_analysis_v2_api

--- a/source/api_documentation/call_api/transcript_analysis_v2_api.rst
+++ b/source/api_documentation/call_api/transcript_analysis_v2_api.rst
@@ -1,0 +1,95 @@
+########################
+Transcript Analysis (v2)
+########################
+
+
+URL
+---
+
+The API follows REST conventions. Perform an HTTPS GET to the URL in order to retrieve Transcript Analysis.
+
+Unlike v1, the v2 endpoint always returns an explicit, per-analysis ``status`` for both the transcript summary and sentiment, so clients never have to interpret a missing field. Each analysis has its own independent lifecycle (sentiment can be available while the summary is still pending, and vice versa).
+
+The following response formats are supported, where CUID-33 is the call record id.
+
+.. list-table::
+  :widths: 8 40
+  :header-rows: 1
+  :class: parameters
+
+  * - Format
+    - Description and URL
+
+  * - json (default)
+    - Returns a JSON object of the transcript analysis. `https://mynetwork.invoca.net/call/v2/transcript_analysis/CUID-33`
+
+Authentication
+--------------
+
+The API uses OAuth to validate access. The OAuth Token can be passed in two ways. The first way is to pass the OAuth Token in the header of the request. The second is to pass the OAuth Token like any other query parameter. Please note that the OAuth Token is a required parameter.
+OAuth Tokens may be generated from the Manage API Credentials page.
+
+Status values
+-------------
+
+``transcript_summary.status``:
+
+.. list-table::
+  :widths: 20 40
+  :header-rows: 1
+  :class: parameters
+
+  * - Status
+    - Meaning
+
+  * - ``available``
+    - The summary has been generated; ``text`` is present.
+
+  * - ``pending``
+    - The summary is enabled and is being (or will be) generated; ``text`` is absent.
+
+  * - ``transcript_too_short``
+    - The transcript was too short to summarize; no summary will be produced.
+
+  * - ``no_transcript``
+    - The call has no transcript; no summary will be produced.
+
+  * - ``not_applicable``
+    - Transcript summaries are not enabled for this network.
+
+``sentiment.status``:
+
+.. list-table::
+  :widths: 20 40
+  :header-rows: 1
+  :class: parameters
+
+  * - Status
+    - Meaning
+
+  * - ``available``
+    - Sentiment has been computed; ``overall``, ``agent``, and ``caller`` scores are present.
+
+  * - ``pending``
+    - Sentiment is enabled and is being (or will be) computed; scores are absent.
+
+  * - ``not_applicable``
+    - Sentiment analysis is not enabled for this network.
+
+Response
+--------
+.. api_endpoint::
+   :verb: GET
+   :path: /call/v2/transcript_analysis/&lt;call_record_id&gt;
+   :description: Get a transcript analysis (summary and sentiment available)
+   :page: get_call_transcript_analysis_v2_available
+
+.. api_endpoint::
+   :verb: GET
+   :path: /call/v2/transcript_analysis/&lt;call_record_id&gt;
+   :description: Get a transcript analysis (summary pending, sentiment not enabled)
+   :page: get_call_transcript_analysis_v2_pending
+
+Endpoint:
+
+``https://mynetwork.invoca.net/call/v2/transcript_analysis/<call_record_id>``


### PR DESCRIPTION
Docs for the new v2 transcript-analysis endpoint shipped in [Invoca/web#30367](https://github.com/Invoca/web/pull/30367) ([MON-22](https://invoca.atlassian.net/browse/MON-22)).

## What

`GET /call/v2/transcript_analysis/<call_record_id>` — exposes explicit per-analysis lifecycle status for both the transcript summary and sentiment, so clients never have to interpret a missing field.

- New page `transcript_analysis_v2_api.rst` (URL, auth, status enums, response section) — mirrors the v1 `transcript_analysis_api` page.
- Example responses: `_get_call_transcript_analysis_v2_available.rst` (summary + sentiment available) and `_get_call_transcript_analysis_v2_pending.rst` (summary pending, sentiment not enabled).
- Wired into the Call API `index.rst`.

Summary status: `available` / `pending` / `transcript_too_short` / `no_transcript` / `not_applicable`.
Sentiment status: `available` / `pending` / `not_applicable`.

v1 docs unchanged.

[MON-22]: https://invoca.atlassian.net/browse/MON-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ