### PR TITLE
JETS-1428: re-home developer-docs to developer-portal system

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,5 +13,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: production-support
-  system: developer-tooling
+  owner: integrations
+  system: developer-portal


### PR DESCRIPTION
`developer-docs` is **customer-facing** API documentation (developers.invoca.net) but was mis-classified under the **internal** `developer-tooling` system with a placeholder `production-support` owner.

- system `developer-tooling` → **`developer-portal`** (the new customer-facing docs System, backstage-catalog#44)
- owner `production-support` → **`integrations`** (the actual codeowners, per Slack)

Pairs with the Mintlify `docs` registration (which is replacing this site). Validated with `@roadiehq/backstage-entity-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)