### PR TITLE
PR template: point 'service owning team' at Backstage (sheet retired)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@
 
 ## Checklist
 
-- [ ] Find the [Service owning team](https://docs.google.com/spreadsheets/d/1YF2wuepY5SZTpVEdT9gwhTPhpnDGZeVjywEwvbJS5TQ/edit#gid=0&fvid=1520238175) for these changes, and tag the team as "Reviewers" on this PR
+- [ ] Find the [Service owning team](https://backstage.invocaops.com) for these changes, and tag the team as "Reviewers" on this PR
 - [ ] Test the documentation changes on readthedocs as a private branch
 - [ ] If changing general content, have agreement on whether to apply to latest version or all versions (if all versions, provide links to the related PRs below)


### PR DESCRIPTION
The ownership spreadsheet is frozen/retired — Backstage + CODEOWNERS is the source of truth. Repoints the checklist link from the sheet to backstage.invocaops.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01TZP25y7fJ77AbeziYjNreF